### PR TITLE
Implement Robust Healthcheck Script for Miner Liveliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ This script will guide you through configuring your wallet, pool, and GPU settin
 ## Features
 
 - **Automated Failover:** Automatically switches to a backup pool if the primary one is unavailable.
-- **Health Monitoring:** Includes a Docker health check to ensure the miner is running correctly.
+- **Health Monitoring:** Includes a robust health check script that monitors both process status and hashrate.
 - **Prometheus Exporter:** Exposes a Prometheus endpoint for easy integration with monitoring tools.
 - **Grafana Dashboard:** Includes a pre-configured Grafana dashboard to visualize your mining performance.
-- **Auto-Restart:** Automatically restarts the container if the miner crashes or becomes unresponsive.
+- **Auto-Restart:** Automatically restarts the container if the miner crashes or stops submitting shares for more than 5 minutes.
 - **Automatic Overclocking:** Apply overclocking settings to your GPUs to improve performance and efficiency.
 
 ## Requirements
@@ -194,7 +194,11 @@ This Docker image includes built-in health checks and a metrics exporter to help
 
 ### Health Check
 
-The container has a Docker health check that verifies the lolMiner API is running and responsive. If the miner crashes or the API becomes unavailable, the container will be marked as "unhealthy" and automatically restarted.
+The container has a Docker health check that verifies:
+1.  The miner process (lolMiner or T-Rex) is running.
+2.  The miner is submitting hashrate.
+
+If the miner process stops, the container will be restarted immediately. If the hashrate remains at 0 for more than 5 minutes (e.g., due to a hung API or driver issue), the health check will also trigger a restart. This ensures maximum uptime and prevents "zombie" mining sessions.
 
 ### Prometheus Exporter
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,7 +1,68 @@
 #!/bin/bash
-if pgrep -x "lolMiner" > /dev/null
-then
+
+# Configuration
+MINER=${MINER:-lolminer}
+API_PORT=4444
+STATE_FILE=${HEALTHCHECK_STATE_FILE:-/tmp/miner_unhealthy_since}
+MAX_UNHEALTHY_TIME=300 # 5 minutes in seconds
+
+# Determine endpoint and process name based on miner
+if [ "$MINER" = "lolminer" ]; then
+    ENDPOINT="/"
+    # lolMiner hashrate is in .Total_Performance[0]
+    QUERY=".Total_Performance[0]"
+    PROCESS_NAME="lolMiner"
+elif [ "$MINER" = "t-rex" ]; then
+    ENDPOINT="/summary"
+    # T-Rex hashrate is in .hashrate
+    QUERY=".hashrate"
+    PROCESS_NAME="t-rex"
+else
+    echo "Unsupported miner: $MINER"
+    exit 0
+fi
+
+# 1. Check if the miner process is running
+if ! pgrep -x "$PROCESS_NAME" > /dev/null; then
+    echo "Miner process $PROCESS_NAME not found!"
+    ./restart.sh
+    exit 1
+fi
+
+# 2. Query the miner's API
+RESPONSE=$(curl -s "http://localhost:${API_PORT}${ENDPOINT}")
+
+# 3. Check if hashrate is > 0
+# We use jq to handle potential float values and ensure robust parsing.
+# If curl fails or RESPONSE is empty, jq will return false or error.
+# We use -e to set exit code based on the result of the expression.
+if echo "$RESPONSE" | jq -e "$QUERY > 0" >/dev/null 2>&1; then
+    # Miner is producing hashrate
+    if [ -f "$STATE_FILE" ]; then
+        echo "Miner recovered. Clearing unhealthy state."
+        rm -f "$STATE_FILE"
+    fi
     exit 0
 else
-    exit 1
+    # Miner is NOT producing hashrate (or API is down)
+    CURRENT_TIME=$(date +%s)
+
+    if [ ! -f "$STATE_FILE" ]; then
+        echo "Miner unhealthy (hashrate 0 or API unreachable). Starting grace period."
+        echo "$CURRENT_TIME" > "$STATE_FILE"
+        exit 0 # Still returning 0 during grace period
+    fi
+
+    START_TIME=$(cat "$STATE_FILE")
+    ELAPSED=$((CURRENT_TIME - START_TIME))
+
+    if [ "$ELAPSED" -ge "$MAX_UNHEALTHY_TIME" ]; then
+        echo "Miner has been unhealthy for $ELAPSED seconds (exceeds $MAX_UNHEALTHY_TIME). Restarting..."
+        rm -f "$STATE_FILE"
+        ./restart.sh
+        exit 1
+    else
+        echo "Miner has been unhealthy for $ELAPSED seconds. (Grace period: $MAX_UNHEALTHY_TIME)"
+        exit 0
+    fi
 fi

--- a/tests/test_healthcheck.sh
+++ b/tests/test_healthcheck.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# tests/test_healthcheck.sh
+
+# Cleanup previous state
+export HEALTHCHECK_STATE_FILE="/tmp/test_miner_unhealthy_since"
+rm -f "$HEALTHCHECK_STATE_FILE"
+rm -f /tmp/mock_api_response /tmp/mock_process_running /tmp/restart_called /tmp/test_output
+
+# Mocking restart.sh
+if [ -f "restart.sh" ]; then
+    mv restart.sh restart.sh.bak
+fi
+
+cat > restart.sh <<EOF
+#!/bin/bash
+echo "RESTART_CALLED" > /tmp/restart_called
+EOF
+chmod +x restart.sh
+
+# Mock pgrep and curl
+MOCK_BIN_DIR=$(mktemp -d)
+export PATH="$MOCK_BIN_DIR:$PATH"
+
+cat > "$MOCK_BIN_DIR/curl" <<EOF
+#!/bin/bash
+cat /tmp/mock_api_response
+EOF
+chmod +x "$MOCK_BIN_DIR/curl"
+
+cat > "$MOCK_BIN_DIR/pgrep" <<EOF
+#!/bin/bash
+if [ -f /tmp/mock_process_running ]; then
+    exit 0
+else
+    exit 1
+fi
+EOF
+chmod +x "$MOCK_BIN_DIR/pgrep"
+
+function run_test() {
+    local name=$1
+    local expected_exit=$2
+    local expected_restart=$3
+
+    echo -n "Running test: $name... "
+    rm -f /tmp/restart_called
+    ./healthcheck.sh > /tmp/test_output 2>&1
+    local actual_exit=$?
+
+    if [ "$actual_exit" -ne "$expected_exit" ]; then
+        echo "FAILED: Expected exit $expected_exit, got $actual_exit"
+        cat /tmp/test_output
+        cleanup
+        exit 1
+    fi
+
+    if [ "$expected_restart" = "yes" ]; then
+        if [ ! -f /tmp/restart_called ]; then
+            echo "FAILED: Expected restart.sh to be called, but it wasn't"
+            cleanup
+            exit 1
+        fi
+    else
+        if [ -f /tmp/restart_called ]; then
+            echo "FAILED: Did not expect restart.sh to be called, but it was"
+            cleanup
+            exit 1
+        fi
+    fi
+    echo "PASSED"
+}
+
+function cleanup() {
+    rm -rf "$MOCK_BIN_DIR"
+    rm -f restart.sh
+    if [ -f "restart.sh.bak" ]; then
+        mv restart.sh.bak restart.sh
+    fi
+    rm -f /tmp/mock_api_response /tmp/mock_process_running /tmp/restart_called /tmp/test_output "$HEALTHCHECK_STATE_FILE"
+}
+
+# --- Test Cases ---
+
+# 1. Healthy lolminer
+export MINER=lolminer
+touch /tmp/mock_process_running
+echo '{"Total_Performance": [100.5]}' > /tmp/mock_api_response
+run_test "Healthy lolminer" 0 "no"
+
+# 2. Healthy t-rex
+export MINER=t-rex
+echo '{"hashrate": 50000000}' > /tmp/mock_api_response
+run_test "Healthy t-rex" 0 "no"
+
+# 3. lolminer 0 hashrate (Grace period starts)
+export MINER=lolminer
+echo '{"Total_Performance": [0]}' > /tmp/mock_api_response
+run_test "lolminer 0 hashrate (start grace)" 0 "no"
+if [ ! -f "$HEALTHCHECK_STATE_FILE" ]; then
+    echo "FAILED: State file not created"
+    cleanup
+    exit 1
+fi
+
+# 4. lolminer 0 hashrate (Within grace period)
+echo $(($(date +%s) - 120)) > "$HEALTHCHECK_STATE_FILE"
+run_test "lolminer 0 hashrate (within grace)" 0 "no"
+
+# 5. lolminer 0 hashrate (After grace period)
+echo $(($(date +%s) - 360)) > "$HEALTHCHECK_STATE_FILE"
+run_test "lolminer 0 hashrate (after grace)" 1 "yes"
+
+# 6. Recovery during grace period
+echo $(($(date +%s) - 120)) > "$HEALTHCHECK_STATE_FILE"
+echo '{"Total_Performance": [100.5]}' > /tmp/mock_api_response
+run_test "Recovery during grace period" 0 "no"
+if [ -f "$HEALTHCHECK_STATE_FILE" ]; then
+    echo "FAILED: State file not removed after recovery"
+    cleanup
+    exit 1
+fi
+
+# 7. Process not running (immediate failure)
+rm /tmp/mock_process_running
+run_test "Process not running" 1 "yes"
+
+cleanup
+echo "All healthcheck tests passed!"


### PR DESCRIPTION
This PR implements a robust healthcheck mechanism for the mining container.
The new healthcheck.sh script:
1. Detects if the miner process (lolMiner or T-Rex) has crashed and triggers an immediate restart via restart.sh.
2. Monitors the total hashrate via the miner's API (port 4444).
3. Implements a 5-minute (300 seconds) grace period for cases where the hashrate is 0 or the API is unreachable (e.g., during startup or temporary network issues).
4. Tracks the unhealthy duration using a state file in /tmp.
5. Triggers a container restart if the unhealthy state persists beyond the grace period.

A new test suite `tests/test_healthcheck.sh` has been added to verify these behaviors in various scenarios. README.md has also been updated to document the improved monitoring.

Fixes #150

---
*PR created automatically by Jules for task [16745732331406505243](https://jules.google.com/task/16745732331406505243) started by @username-anthony-is-not-available*