### PR TITLE
Implement Rootless Docker and non-root execution support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Implement 'Rootless Docker' support by running the miner process as a non-root user (`miner`).
 - Support for `EXTRA_ARGS` environment variable to pass custom flags to both lolMiner and T-Rex.
 - Full miner log download feature in the web dashboard.
 - Miner selection (lolMiner vs T-Rex) and `EXTRA_ARGS` configuration in the web dashboard.
@@ -34,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detailed per-GPU timeseries for Dual Hashrate, Fan Speed, and Power Draw in Grafana.
 
 ### Changed
+- Updated Dockerfiles to include `gosu` and a non-root `miner` user (UID 1000).
+- Modified `start.sh` to drop privileges to the `miner` user after performing root-level operations like overclocking.
 - Refactored `dashboard.py` and `metrics.py` to use the centralized `miner_api.py`.
 - Generalized dashboard title from "lolMiner Dashboard" to "Miner Dashboard".
 - Configured miners to log to `miner.log` for persistent access in the dashboard.

--- a/Dockerfile.amd
+++ b/Dockerfile.amd
@@ -28,8 +28,17 @@ RUN apt-get update && \
     python3 \
     python3-pip \
     rocm-smi \
-    procps && \
+    procps \
+    gosu && \
     rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user
+RUN groupadd -g 1000 miner && \
+    useradd -u 1000 -g miner -m -s /bin/bash miner && \
+    # Add miner to video and render groups for GPU access
+    (groupadd -r video || true) && \
+    (groupadd -r render || true) && \
+    usermod -aG video,render miner
 
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
@@ -43,7 +52,8 @@ COPY dashboard.py .
 COPY templates/ templates/
 COPY static/ static/
 
-RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh
+RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh && \
+    chown -R miner:miner /app
 
 EXPOSE 4444 4455 4456
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This script will guide you through configuring your wallet, pool, and GPU settin
 - **Grafana Dashboard:** Includes a pre-configured Grafana dashboard to visualize your mining performance.
 - **Auto-Restart:** Automatically restarts the container if the miner crashes or stops submitting shares for more than 5 minutes.
 - **Automatic Overclocking:** Apply overclocking settings to your GPUs to improve performance and efficiency.
+- **Enhanced Security:** The miner runs as a non-root user (`miner`) inside the container by default. It also supports Rootless Docker environments.
 
 ## Requirements
 
@@ -154,6 +155,28 @@ To enable overclocking, set the `APPLY_OC` environment variable to `true` in you
 -   `GPU_POWER_LIMIT`: The desired GPU power limit in watts.
 
 The overclocking settings will be applied to all GPUs visible within the container.
+
+**Security Note:** Applying overclocking settings requires the container to be started as `root` (UID 0). The `start.sh` script will apply the settings as root and then immediately drop privileges to the non-root `miner` user for the actual mining process.
+
+## Security & Rootless Docker
+
+This project is designed with security in mind.
+
+### Non-Root Execution
+By default, the mining process, dashboard, and metrics exporter run as a non-root user named `miner` (UID 1000) inside the container. This limits the potential impact of any vulnerability in the mining software.
+
+### Rootless Docker Support
+The image is compatible with [Rootless Docker](https://docs.docker.com/engine/security/rootless/). When running in a rootless environment:
+- The container's `root` (UID 0) is mapped to your host user.
+- The `start.sh` script will still function, but applying overclocking settings might require additional host-side configuration or may not be possible depending on your driver setup.
+- Ensure your host user has permissions to access the GPU device nodes (`/dev/nvidia*` or `/dev/kfd`, `/dev/dri`).
+
+### Running without Root Privileges
+If you wish to run the container without *any* root privileges inside (i.e., skipping the initial root-based setup), you can start the container as UID 1000:
+```bash
+docker run --user 1000:1000 ...
+```
+*Note: If started as a non-root user, the automatic overclocking feature will be skipped as it requires root privileges.*
 
 
 ### GPU Tuning Profiles

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,8 @@ echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}   Ergo Miner Setup Assistant          ${NC}"
 echo -e "${BLUE}========================================${NC}"
 echo "This script will help you configure your Ergo miner."
+echo -e "${GREEN}Security Tip: This miner now runs as a non-root user (UID 1000)${NC}"
+echo -e "${GREEN}inside the container for improved security.${NC}"
 
 # Check for Docker
 if ! command -v docker &> /dev/null; then


### PR DESCRIPTION
This PR implements support for running the mining container as a non-root user, which is a key requirement for Rootless Docker environments and a general security best practice.

Key changes:
1. **Dockerfiles**: Both NVIDIA and AMD Dockerfiles now create a `miner` user and group (UID 1000) and install `gosu` for graceful privilege dropping.
2. **Privilege Management**: The `start.sh` entrypoint script has been refactored. It starts as root to perform necessary system-level tasks (such as setting GPU power limits and overclocking) and then uses `gosu` to drop privileges and execute the miner, dashboard, and metrics exporter as the `miner` user.
3. **GPU Access**: The `miner` user is added to the `video` and `render` groups within the container, ensuring it can access `/dev/nvidia*` or `/dev/kfd` device nodes.
4. **Documentation**: The README has been updated with a new section on "Security & Rootless Docker", explaining how the privilege dropping works and how users can further restrict the container if they don't need the overclocking features.

These changes significantly reduce the attack surface by ensuring that the mining software (lolMiner or T-Rex) does not run with root privileges.

Fixes #124

---
*PR created automatically by Jules for task [15684234839182590826](https://jules.google.com/task/15684234839182590826) started by @username-anthony-is-not-available*