### PR TITLE
[Tech-Debt] Migrated from 'Flask' to 'FastAPI' for dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detailed per-GPU timeseries for Dual Hashrate, Fan Speed, and Power Draw in Grafana.
 
 ### Changed
+- Migrated the web dashboard from Flask to FastAPI for improved performance and async support.
 - Updated Dockerfiles to include `gosu` and a non-root `miner` user (UID 1000).
 - Modified `start.sh` to drop privileges to the `miner` user after performing root-level operations like overclocking.
 - Refactored `dashboard.py` and `metrics.py` to use the centralized `miner_api.py`.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,55 +1,77 @@
-from flask import Flask, render_template, jsonify, request, send_file
-from flask_socketio import SocketIO, emit
-import time
-from threading import Thread
+import socketio
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+import asyncio
 import os
 import subprocess
 import logging
 from typing import Dict, Any, Optional
 import database
 from miner_api import get_full_miner_data, get_gpu_names
-
-app = Flask(__name__)
-socketio = SocketIO(app)
+from contextlib import asynccontextmanager
 
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
-logger = app.logger
+logger = logging.getLogger("dashboard")
 
 # Global variable to store the latest miner data
 miner_data: Dict[str, Any] = {
     'status': 'Starting...'
 }
 
-def background_thread() -> None:
+sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup
+    database.init_db()
+    task = asyncio.create_task(background_task())
+    yield
+    # Shutdown
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+app = FastAPI(lifespan=lifespan)
+sio_app = socketio.ASGIApp(sio, app)
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+templates = Jinja2Templates(directory="templates")
+
+async def background_task() -> None:
     """Continuously fetches and broadcasts miner data."""
     while True:
         global miner_data
         try:
-            data = get_full_miner_data()
+            # get_full_miner_data is synchronous, but we can run it in a thread to not block the event loop
+            data = await asyncio.to_thread(get_full_miner_data)
             if data:
                 miner_data = data
-                socketio.emit('update', miner_data)
+                await sio.emit('update', miner_data)
             else:
                 miner_data['status'] = 'Error: Miner API unreachable'
-                socketio.emit('update', miner_data)
+                await sio.emit('update', miner_data)
         except Exception as e:
-            logger.error(f"Error in background thread: {e}")
+            logger.error(f"Error in background task: {e}")
             miner_data['status'] = f"Error: {str(e)}"
-            socketio.emit('update', miner_data)
+            await sio.emit('update', miner_data)
 
-        time.sleep(5)
+        await asyncio.sleep(5)
 
-@app.route('/')
-def index():
-    return render_template('index.html')
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse(request, "index.html")
 
-@app.route('/config')
-def config():
-    return render_template('config.html')
+@app.get("/config", response_class=HTMLResponse)
+async def config(request: Request):
+    return templates.TemplateResponse(request, "config.html")
 
 def read_env_file() -> Dict[str, str]:
     env_vars = {}
@@ -89,78 +111,74 @@ def write_env_file(env_vars: Dict[str, str]) -> None:
     with open('.env', 'w') as f:
         f.writelines(new_lines)
 
-@app.route('/api/config', methods=['GET', 'POST'])
-def manage_config():
-    if request.method == 'POST':
-        data = request.json
-        env_vars = read_env_file()
-        for key, value in data.items():
-            if value is True: value = 'true'
-            if value is False: value = 'false'
-            env_vars[key] = str(value)
-        write_env_file(env_vars)
-        return jsonify({'message': 'Configuration saved successfully!'})
-    else:
-        return jsonify(read_env_file())
+@app.get("/api/config")
+async def get_config():
+    return read_env_file()
 
-@app.route('/api/restart', methods=['POST'])
-def restart():
+@app.post("/api/config")
+async def post_config(request: Request):
+    data = await request.json()
+    env_vars = read_env_file()
+    for key, value in data.items():
+        if value is True: value = 'true'
+        if value is False: value = 'false'
+        env_vars[key] = str(value)
+    write_env_file(env_vars)
+    return {"message": "Configuration saved successfully!"}
+
+@app.post("/api/restart")
+async def restart():
     try:
-        subprocess.run(['./restart.sh'], check=True)
-        return jsonify({'message': 'Restarting...'})
+        # Run in thread to avoid blocking if it takes time
+        await asyncio.to_thread(subprocess.run, ['./restart.sh'], check=True)
+        return {"message": "Restarting..."}
     except subprocess.CalledProcessError as e:
         logger.error(f"Error executing restart script: {e}")
-        return jsonify({'message': 'Restart failed!'}), 500
+        return JSONResponse(status_code=500, content={"message": "Restart failed!"})
 
-@app.route('/hashrate-history')
-def hashrate_history():
-    history = database.get_history()
-    return jsonify(history)
+@app.get("/hashrate-history")
+async def hashrate_history():
+    history = await asyncio.to_thread(database.get_history)
+    return history
 
-@app.route('/api/logs')
-def get_logs():
+@app.get("/api/logs")
+async def get_logs():
     try:
         if os.path.exists('miner.log'):
             # Return last 100 lines
-            with open('miner.log', 'r') as f:
-                lines = f.readlines()
-                return jsonify({'logs': ''.join(lines[-100:])})
+            import aiofiles
+            async with aiofiles.open('miner.log', mode='r') as f:
+                lines = await f.readlines()
+                return {"logs": "".join(lines[-100:])}
         else:
-            return jsonify({'logs': 'Miner log file not found. Waiting for miner to start...'})
+            return {"logs": "Miner log file not found. Waiting for miner to start..."}
     except Exception as e:
         logger.error(f"Error reading log file: {e}")
-        return jsonify({'error': str(e)}), 500
+        return JSONResponse(status_code=500, content={"error": str(e)})
 
-@app.route('/api/logs/download')
-def download_logs():
-    try:
-        if os.path.exists('miner.log'):
-            return send_file('miner.log', as_attachment=True)
-        else:
-            return "Log file not found", 404
-    except Exception as e:
-        logger.error(f"Error downloading log file: {e}")
-        return str(e), 500
+@app.get("/api/logs/download")
+async def download_logs():
+    if os.path.exists('miner.log'):
+        return FileResponse('miner.log', filename='miner.log')
+    else:
+        return JSONResponse(status_code=404, content={"message": "Log file not found"})
 
-@app.route('/api/gpu-models')
-def get_gpu_models():
+@app.get("/api/gpu-models")
+async def api_get_gpu_models():
     """Returns the detected GPU models."""
     try:
-        models = get_gpu_names()
-        return jsonify({'models': models})
+        models = await asyncio.to_thread(get_gpu_names)
+        return {"models": models}
     except Exception as e:
         logger.error(f"Error fetching GPU models: {e}")
-        return jsonify({'error': str(e)}), 500
+        return JSONResponse(status_code=500, content={"error": str(e)})
 
-@socketio.on('connect')
-def handle_connect():
+@sio.on('connect')
+async def handle_connect(sid, environ):
     """Sends the initial data to the client upon connection."""
     if miner_data:
-        emit('update', miner_data)
+        await sio.emit('update', miner_data, to=sid)
 
 if __name__ == '__main__':
-    database.init_db()
-    thread = Thread(target=background_thread)
-    thread.daemon = True
-    thread.start()
-    socketio.run(app, host='0.0.0.0', port=5000, allow_unsafe_werkzeug=True)
+    import uvicorn
+    uvicorn.run("dashboard:sio_app", host='0.0.0.0', port=5000, reload=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-Flask==3.0.0
-Flask-SocketIO==5.3.0
+fastapi==0.115.0
+uvicorn==0.30.6
+python-socketio==5.11.0
+jinja2==3.1.4
+aiofiles==24.1.0
+httpx==0.27.0
 prometheus-client==0.24.1
-Werkzeug==3.0.0
 requests==2.32.4

--- a/start.sh
+++ b/start.sh
@@ -90,7 +90,7 @@ fi
 ./metrics.sh &
 
 # Start the dashboard in the background
-python3 dashboard.py &
+uvicorn dashboard:sio_app --host 0.0.0.0 --port 5000 &
 
 # Start GPU monitoring in the background based on available tools
 if command -v nvidia-smi &> /dev/null; then


### PR DESCRIPTION
This change migrates the web dashboard from Flask to FastAPI, providing a more modern and performant async API. It includes a full refactor of `dashboard.py`, updates to the startup script, and modernized test suites. WebSockets are now handled via `python-socketio`'s ASGI implementation.

Fixes #123

---
*PR created automatically by Jules for task [2361318311773861369](https://jules.google.com/task/2361318311773861369) started by @username-anthony-is-not-available*