### PR TITLE
Implement Telegram Bot notifications for downtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,12 @@ EXTRA_ARGS=
 # Auto Profit Switching
 AUTO_PROFIT_SWITCHING=false
 
+# Telegram Notifications
+TELEGRAM_ENABLE=false
+# TELEGRAM_BOT_TOKEN=your_bot_token
+# TELEGRAM_CHAT_ID=your_chat_id
+# TELEGRAM_NOTIFY_THRESHOLD=300
+
 # Dual Mining (lolMiner only)
 # DUAL_ALGO=KASPADUAL
 # DUAL_POOL=stratum+tcp://kas.2miners.com:2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Implement 'Telegram Bot' notifications for rig downtime and recovery.
+- New interactive Telegram configuration prompts in `setup.sh`.
 - Implement 'Auto-Profit Switching' between pools via a background supervisor.
 - Implement 'Rootless Docker' support by running the miner process as a non-root user (`miner`).
 - Support for `EXTRA_ARGS` environment variable to pass custom flags to both lolMiner and T-Rex.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This script will guide you through configuring your wallet, pool, and GPU settin
 - **Auto-Restart:** Automatically restarts the container if the miner crashes or stops submitting shares for more than 5 minutes.
 - **Automatic Overclocking:** Apply overclocking settings to your GPUs to improve performance and efficiency.
 - **Auto-Profit Switching:** Automatically switches to the most profitable pool based on real-time stats to maximize your earnings.
+- **Telegram Notifications:** Receive instant alerts on your phone when your rig goes down or experiences zero hashrate.
 - **Enhanced Security:** The miner runs as a non-root user (`miner`) inside the container by default. It also supports Rootless Docker environments.
 
 ## Requirements
@@ -125,6 +126,10 @@ By default, the file is configured for a two-GPU setup. To add more GPUs, you ca
 -   `DUAL_WALLET`: (lolMiner only) Your wallet address for the second coin.
 -   `DUAL_WORKER`: (lolMiner only) Optional worker name for the dual mining pool (defaults to `WORKER_NAME`).
 -   `AUTO_PROFIT_SWITCHING`: Set to `true` to enable the automatic pool switching feature.
+-   `TELEGRAM_ENABLE`: Set to `true` to enable Telegram notifications.
+-   `TELEGRAM_BOT_TOKEN`: Your Telegram Bot API token.
+-   `TELEGRAM_CHAT_ID`: Your Telegram Chat ID.
+-   `TELEGRAM_NOTIFY_THRESHOLD`: Grace period in seconds before sending a downtime notification (default: `300`).
 
 ## Auto-Profit Switching
 
@@ -230,6 +235,20 @@ The container has a Docker health check that verifies:
 2.  The miner is submitting hashrate.
 
 If the miner process stops, the container will be restarted immediately. If the hashrate remains at 0 for more than 5 minutes (e.g., due to a hung API or driver issue), the health check will also trigger a restart. This ensures maximum uptime and prevents "zombie" mining sessions.
+
+### Telegram Notifications
+
+You can receive instant alerts on your phone when your rig goes down. This feature is integrated into the metrics exporter and will notify you if:
+1. The miner process crashes.
+2. The miner API is unreachable.
+3. The rig produces zero hashrate for a sustained period.
+
+To set up Telegram notifications:
+1. Create a new bot using [BotFather](https://t.me/botfather) and get your **Bot Token**.
+2. Get your **Chat ID** (you can use a bot like [@userinfobot](https://t.me/userinfobot)).
+3. Enable the feature during the interactive setup or by setting the `TELEGRAM_*` variables in your `.env` file.
+
+The default notification threshold is 300 seconds (5 minutes), meaning you will only receive an alert if the rig stays down for that duration. You will also receive a follow-up message once the rig recovers.
 
 ### Prometheus Exporter
 

--- a/setup.sh
+++ b/setup.sh
@@ -171,6 +171,19 @@ else
     AUTO_PROFIT_SWITCHING="false"
 fi
 
+# 10. Telegram Notifications
+echo -e "\n${GREEN}10. Telegram Notifications${NC}"
+read -p "Enable Telegram Notifications for downtime? (y/n) [n]: " TELEGRAM_CHOICE
+if [[ "$TELEGRAM_CHOICE" =~ ^[Yy]$ ]]; then
+    TELEGRAM_ENABLE="true"
+    read -p "Enter Telegram Bot Token: " TELEGRAM_BOT_TOKEN
+    read -p "Enter Telegram Chat ID: " TELEGRAM_CHAT_ID
+    read -p "Enter Notification Threshold (seconds) [300]: " TELEGRAM_NOTIFY_THRESHOLD
+    TELEGRAM_NOTIFY_THRESHOLD=${TELEGRAM_NOTIFY_THRESHOLD:-300}
+else
+    TELEGRAM_ENABLE="false"
+fi
+
 # Generate .env file
 echo -e "\n${BLUE}Generating .env file...${NC}"
 cat <<EOF > .env
@@ -195,7 +208,18 @@ APPLY_OC=${APPLY_OC}
 
 # Profit Switching
 AUTO_PROFIT_SWITCHING=${AUTO_PROFIT_SWITCHING}
+
+# Telegram Notifications
+TELEGRAM_ENABLE=${TELEGRAM_ENABLE}
 EOF
+
+if [ "$TELEGRAM_ENABLE" == "true" ]; then
+    cat <<EOF >> .env
+TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
+TELEGRAM_NOTIFY_THRESHOLD=${TELEGRAM_NOTIFY_THRESHOLD}
+EOF
+fi
 
 if [ -n "$GPU_PROFILE" ]; then
     echo "GPU_PROFILE=$GPU_PROFILE" >> .env

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -26,6 +26,10 @@ fi
 # Dual Worker: test-worker-dual
 # Extra Args: --extra-param 1
 # Profit Switch: y
+# Telegram: y
+# Telegram Token: MyToken
+# Telegram ID: MyID
+# Telegram Threshold: 600
 # Start now: n
 ./setup.sh <<EOF
 MyTestWallet
@@ -43,6 +47,10 @@ MyDualPool
 test-worker-dual
 --extra-param 1
 y
+y
+MyToken
+MyID
+600
 n
 EOF
 
@@ -76,6 +84,10 @@ check_var "DUAL_POOL=MyDualPool"
 check_var "DUAL_WORKER=test-worker-dual"
 check_var "EXTRA_ARGS=--extra-param 1"
 check_var "AUTO_PROFIT_SWITCHING=true"
+check_var "TELEGRAM_ENABLE=true"
+check_var "TELEGRAM_BOT_TOKEN=MyToken"
+check_var "TELEGRAM_CHAT_ID=MyID"
+check_var "TELEGRAM_NOTIFY_THRESHOLD=600"
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "setup.sh test 1 PASSED"
@@ -94,6 +106,7 @@ echo "Running setup.sh test 2 (AMD, Defaults)..."
 # GPU Count: default (AUTO)
 # Extra Args: empty
 # Profit Switching: n
+# Telegram: n
 # Start now: n
 ./setup.sh <<EOF
 AmdWallet
@@ -105,6 +118,7 @@ AmdWallet
 
 n
 n
+n
 EOF
 
 check_var "WALLET_ADDRESS=AmdWallet"
@@ -114,6 +128,7 @@ check_var "MINER=lolminer"
 check_var "GPU_DEVICES=AUTO"
 check_var "APPLY_OC=false"
 check_var "AUTO_PROFIT_SWITCHING=false"
+check_var "TELEGRAM_ENABLE=false"
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "setup.sh test 2 PASSED"

--- a/tests/test_telegram_notifications.py
+++ b/tests/test_telegram_notifications.py
@@ -1,0 +1,138 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import time
+
+# Add the root directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import metrics
+from metrics import update_metrics
+
+class TestTelegramNotifications(unittest.TestCase):
+    def setUp(self):
+        # Reset state
+        metrics.unhealthy_since = None
+        metrics.is_currently_notified = False
+        metrics.TELEGRAM_ENABLE = True
+        metrics.TELEGRAM_BOT_TOKEN = "fake_token"
+        metrics.TELEGRAM_CHAT_ID = "fake_chat_id"
+        metrics.TELEGRAM_NOTIFY_THRESHOLD = 10 # 10 seconds for testing
+
+    @patch('database.log_history')
+    @patch('database.prune_history')
+    @patch('metrics.send_telegram_notification')
+    @patch('metrics.get_full_miner_data')
+    def test_notification_sent_after_threshold(self, mock_full_data, mock_send, mock_prune, mock_log):
+        # Rig is down
+        mock_full_data.return_value = None
+
+        # Mock time to be stable
+        start_time = 1000000.0
+        with patch('time.time', return_value=start_time):
+            # First check: mark unhealthy
+            update_metrics()
+            self.assertEqual(metrics.unhealthy_since, start_time)
+            mock_send.assert_not_called()
+
+        # Second check: Fast forward time past threshold
+        with patch('time.time', return_value=start_time + 15):
+            update_metrics()
+            mock_send.assert_called_once()
+            self.assertTrue(metrics.is_currently_notified)
+
+            # Check reason in message
+            args, _ = mock_send.call_args
+            self.assertIn("API Unreachable", args[0])
+            self.assertIn("Duration: 15s", args[0])
+
+    @patch('database.log_history')
+    @patch('database.prune_history')
+    @patch('metrics.send_telegram_notification')
+    @patch('metrics.get_full_miner_data')
+    def test_notification_recovery(self, mock_full_data, mock_send, mock_prune, mock_log):
+        # Set state to notified
+        metrics.unhealthy_since = 1000000.0 - 20
+        metrics.is_currently_notified = True
+
+        # Rig recovered
+        mock_full_data.return_value = {
+            'total_hashrate': 100.5,
+            'status': 'Mining',
+            'total_dual_hashrate': 0,
+            'avg_fan_speed': 50,
+            'total_power_draw': 200,
+            'total_accepted_shares': 10,
+            'total_rejected_shares': 0,
+            'avg_temperature': 60,
+            'gpus': []
+        }
+
+        update_metrics()
+
+        # Recovery message should be sent
+        mock_send.assert_called_once()
+        self.assertIn("RECOVERED", mock_send.call_args[0][0])
+        self.assertIn("Hashrate: 100.5 MH/s", mock_send.call_args[0][0])
+        self.assertFalse(metrics.is_currently_notified)
+        self.assertIsNone(metrics.unhealthy_since)
+
+    @patch('database.log_history')
+    @patch('database.prune_history')
+    @patch('metrics.send_telegram_notification')
+    @patch('metrics.get_full_miner_data')
+    def test_zero_hashrate_notification(self, mock_full_data, mock_send, mock_prune, mock_log):
+        # Rig is up but 0 hashrate
+        mock_full_data.return_value = {
+            'total_hashrate': 0,
+            'status': 'Idle',
+            'total_dual_hashrate': 0,
+            'avg_fan_speed': 50,
+            'total_power_draw': 200,
+            'total_accepted_shares': 10,
+            'total_rejected_shares': 0,
+            'avg_temperature': 60,
+            'gpus': []
+        }
+
+        start_time = 1000000.0
+        with patch('time.time', return_value=start_time):
+            # First check
+            update_metrics()
+            self.assertEqual(metrics.unhealthy_since, start_time)
+
+        # Fast forward
+        with patch('time.time', return_value=start_time + 15):
+            update_metrics()
+            mock_send.assert_called_once()
+            self.assertIn("Zero Hashrate", mock_send.call_args[0][0])
+
+    @patch('requests.post')
+    def test_send_telegram_notification_actual_call(self, mock_post):
+        metrics.TELEGRAM_ENABLE = True
+        metrics.TELEGRAM_BOT_TOKEN = "test_token"
+        metrics.TELEGRAM_CHAT_ID = "test_chat"
+
+        from metrics import send_telegram_notification
+
+        # Success case
+        mock_post.return_value.raise_for_status = MagicMock()
+        send_telegram_notification("Test message")
+
+        mock_post.assert_called_once()
+        url = mock_post.call_args[0][0]
+        self.assertIn("test_token", url)
+        json_data = mock_post.call_args[1]['json']
+        self.assertEqual(json_data['chat_id'], "test_chat")
+        self.assertEqual(json_data['text'], "Test message")
+
+    @patch('requests.post')
+    def test_send_telegram_notification_disabled(self, mock_post):
+        metrics.TELEGRAM_ENABLE = False
+        from metrics import send_telegram_notification
+        send_telegram_notification("Test message")
+        mock_post.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This feature adds an optional Telegram notification service to the `metrics.py` script. Users can now receive alerts on their phone when their mining rig goes down (due to process crash, unreachable API, or zero hashrate) or recovers. The feature includes a configurable grace period to avoid flapping notifications and is integrated into the interactive setup script.

Fixes #121

---
*PR created automatically by Jules for task [689481278510851471](https://jules.google.com/task/689481278510851471) started by @username-anthony-is-not-available*