### PR TITLE
Add One-Click Multi-GPU discovery and MULTI_PROCESS mining mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ T_REX_VERSION=0.26.8
 
 # GPU Selection (AUTO or comma-separated list like 0,1)
 GPU_DEVICES=AUTO
+# Set to true to run one miner process per GPU (useful for stability/isolation)
+MULTI_PROCESS=false
 
 # Overclocking (NVIDIA only)
 APPLY_OC=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Implement 'One-Click Multi-GPU' discovery in `start.sh` for both NVIDIA and AMD.
+- Add support for `MULTI_PROCESS` mining mode, running one miner process per GPU for improved isolation and stability.
 - Implement 'Telegram Bot' notifications for rig downtime and recovery.
 - New interactive Telegram configuration prompts in `setup.sh`.
 - Implement 'Auto-Profit Switching' between pools via a background supervisor.


### PR DESCRIPTION
Implemented 'One-Click Multi-GPU' discovery and an optional 'MULTI_PROCESS' mining mode. 

- **GPU Discovery**: `start.sh` now automatically detects NVIDIA and AMD GPUs if `GPU_DEVICES` is set to `AUTO`.
- **Multi-Process Mining**: Users can set `MULTI_PROCESS=true` to run a separate miner process for each GPU. This improves stability by isolating GPU failures.
- **Aggregated Monitoring**: `miner_api.py` and `healthcheck.sh` have been updated to seamlessly aggregate data from multiple miner instances, ensuring the dashboard and metrics continue to show rig-wide statistics.
- **Cleanup**: Added robust signal handling in `start.sh` to ensure all background miners are terminated when the container stops.
- **Testing**: Added new test cases to `tests/test_miner_api.py` and `tests/test_healthcheck.sh` to verify the multi-process logic.

Fixes #120

---
*PR created automatically by Jules for task [664286569154471004](https://jules.google.com/task/664286569154471004) started by @username-anthony-is-not-available*