### PR TITLE
Add Eco Mode underclocking profiles for RTX 30/40 series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add 'Eco Mode' underclocking profiles for RTX 30/40 series GPUs.
 - Implement 'One-Click Multi-GPU' discovery in `start.sh` for both NVIDIA and AMD.
 - Add support for `MULTI_PROCESS` mining mode, running one miner process per GPU for improved isolation and stability.
 - Implement 'Telegram Bot' notifications for rig downtime and recovery.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,16 @@ To use the "RTX 3070" profile, set `GPU_PROFILE=RTX 3070` in your `.env` file.
 
 If `GPU_PROFILE` is set, it will override any values set for `GPU_CLOCK_OFFSET`, `GPU_MEM_OFFSET`, and `GPU_POWER_LIMIT`. If the specified profile is not found in `gpu_profiles.json`, the script will fall back to using the individual environment variables.
 
+### **Eco Mode**
+
+The image includes a "Eco Mode" feature for NVIDIA RTX 30 and 40 series GPUs. When enabled, it automatically switches to a more conservative tuning profile that reduces power consumption while maintaining a solid hashrate for Ergo.
+
+To enable Eco Mode:
+1. Set `APPLY_OC=true` and `ECO_MODE=true` in your `.env` file.
+2. Select a compatible `GPU_PROFILE` (e.g., `RTX 3070`) or use `AUTO` detection.
+
+The miner will automatically look for an "(Eco)" version of your profile in `gpu_profiles.json` and apply those settings (lower power limits and core clock offsets).
+
 ## Verifying the Setup
 
 You can monitor the miner's output and view logs using the following command:

--- a/gpu_profiles.json
+++ b/gpu_profiles.json
@@ -4,34 +4,69 @@
     "GPU_MEM_OFFSET": 1200,
     "GPU_POWER_LIMIT": 120
   },
+  "RTX 3060 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1200,
+    "GPU_POWER_LIMIT": 90
+  },
   "RTX 3070": {
     "GPU_CLOCK_OFFSET": -200,
     "GPU_MEM_OFFSET": 1300,
     "GPU_POWER_LIMIT": 130
+  },
+  "RTX 3070 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 110
   },
   "RTX 3080": {
     "GPU_CLOCK_OFFSET": -200,
     "GPU_MEM_OFFSET": 1500,
     "GPU_POWER_LIMIT": 240
   },
+  "RTX 3080 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 190
+  },
   "RTX 3060 Ti": {
     "GPU_CLOCK_OFFSET": -200,
     "GPU_MEM_OFFSET": 1200,
     "GPU_POWER_LIMIT": 130
+  },
+  "RTX 3060 Ti (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1200,
+    "GPU_POWER_LIMIT": 100
   },
   "RTX 3090": {
     "GPU_CLOCK_OFFSET": -200,
     "GPU_MEM_OFFSET": 1000,
     "GPU_POWER_LIMIT": 300
   },
+  "RTX 3090 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1000,
+    "GPU_POWER_LIMIT": 250
+  },
   "RTX 4070": {
     "GPU_CLOCK_OFFSET": -200,
     "GPU_MEM_OFFSET": 1300,
     "GPU_POWER_LIMIT": 150
   },
+  "RTX 4070 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 120
+  },
   "RTX 4090": {
     "GPU_CLOCK_OFFSET": -200,
     "GPU_MEM_OFFSET": 1500,
     "GPU_POWER_LIMIT": 350
+  },
+  "RTX 4090 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 280
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -121,6 +121,7 @@ fi
 # 6. Overclocking (NVIDIA only)
 APPLY_OC="false"
 GPU_PROFILE=""
+ECO_MODE="false"
 if [ "$GPU_TYPE" == "NVIDIA" ]; then
     read -p "Apply Overclocking? (y/n) [n]: " APPLY_OC_CHOICE
     if [[ "$APPLY_OC_CHOICE" =~ ^[Yy]$ ]]; then
@@ -133,6 +134,11 @@ if [ "$GPU_TYPE" == "NVIDIA" ]; then
                 grep -o '"[^"]*": {' gpu_profiles.json | tr -d '": {'
             fi
             read -p "Enter a profile name (e.g. RTX 3070) or leave blank: " GPU_PROFILE
+        fi
+
+        read -p "Enable Eco Mode? (y/n) [n]: " ECO_MODE_CHOICE
+        if [[ "$ECO_MODE_CHOICE" =~ ^[Yy]$ ]]; then
+            ECO_MODE="true"
         fi
     fi
 fi
@@ -205,6 +211,7 @@ GPU_DEVICES=${GPU_DEVICES}
 
 # Overclocking
 APPLY_OC=${APPLY_OC}
+ECO_MODE=${ECO_MODE}
 
 # Profit Switching
 AUTO_PROFIT_SWITCHING=${AUTO_PROFIT_SWITCHING}

--- a/start.sh
+++ b/start.sh
@@ -49,6 +49,17 @@ except Exception:
     fi
 
     if [ -n "$GPU_PROFILE" ] && [ "$GPU_PROFILE" != "null" ] && [ -f "gpu_profiles.json" ]; then
+      # Handle Eco Mode
+      if [ "$ECO_MODE" = "true" ]; then
+        ECO_PROFILE="$GPU_PROFILE (Eco)"
+        if jq -e ".[\"$ECO_PROFILE\"]" gpu_profiles.json > /dev/null; then
+          echo "Eco Mode enabled. Switching to $ECO_PROFILE"
+          GPU_PROFILE="$ECO_PROFILE"
+        else
+          echo "Eco Mode enabled, but no Eco profile found for $GPU_PROFILE. Using standard profile."
+        fi
+      fi
+
       echo "Using GPU profile: $GPU_PROFILE"
       PROFILE_SETTINGS=$(jq -r ".[\"$GPU_PROFILE\"]" gpu_profiles.json)
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -57,6 +57,10 @@
                 <input type="checkbox" id="apply_oc" name="APPLY_OC">
             </div>
             <div class="form-group">
+                <label for="eco_mode">Enable Eco Mode</label>
+                <input type="checkbox" id="eco_mode" name="ECO_MODE">
+            </div>
+            <div class="form-group">
                 <label for="gpu_profile">GPU Profile</label>
                 <input type="text" id="gpu_profile" name="GPU_PROFILE">
             </div>
@@ -92,6 +96,7 @@
                     document.getElementById('extra_args').value = data.EXTRA_ARGS || '';
                     document.getElementById('auto_profit_switching').checked = data.AUTO_PROFIT_SWITCHING === 'true';
                     document.getElementById('apply_oc').checked = data.APPLY_OC === 'true';
+                    document.getElementById('eco_mode').checked = data.ECO_MODE === 'true';
                     document.getElementById('gpu_profile').value = data.GPU_PROFILE || '';
                     document.getElementById('gpu_clock_offset').value = data.GPU_CLOCK_OFFSET || 0;
                     document.getElementById('gpu_mem_offset').value = data.GPU_MEM_OFFSET || 0;
@@ -106,6 +111,7 @@
                     data[key] = value;
                 }
                 data['APPLY_OC'] = document.getElementById('apply_oc').checked;
+                data['ECO_MODE'] = document.getElementById('eco_mode').checked;
                 data['AUTO_PROFIT_SWITCHING'] = document.getElementById('auto_profit_switching').checked;
                 fetch('/api/config', {
                     method: 'POST',

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -19,6 +19,7 @@ fi
 # GPU Count: 2 (0,1)
 # Apply OC: y
 # Profile: RTX 3070
+# Eco Mode: y
 # Dual Mining: y
 # Dual Algo: 1 (Kaspa)
 # Dual Wallet: MyDualWallet
@@ -40,6 +41,7 @@ test-worker
 2
 y
 RTX 3070
+y
 y
 1
 MyDualWallet
@@ -77,6 +79,7 @@ check_var "POOL_ADDRESS=stratum+tcp://herominers.com:1180"
 check_var "MINER=lolminer"
 check_var "GPU_DEVICES=0,1"
 check_var "APPLY_OC=true"
+check_var "ECO_MODE=true"
 check_var "GPU_PROFILE=RTX 3070"
 check_var "DUAL_ALGO=KASPADUAL"
 check_var "DUAL_WALLET=MyDualWallet"
@@ -122,6 +125,7 @@ n
 EOF
 
 check_var "WALLET_ADDRESS=AmdWallet"
+check_var "ECO_MODE=false"
 check_var "WORKER_NAME=ergo-miner"
 check_var "POOL_ADDRESS=stratum+tcp://erg.2miners.com:8080"
 check_var "MINER=lolminer"


### PR DESCRIPTION
Implemented Eco Mode for RTX 30/40 series GPUs to reduce power draw while mining Ergo. Added predefined eco-profiles, updated start.sh for automatic application, and enhanced setup.sh and the web dashboard with Eco Mode toggles. Verified with unit tests and frontend screenshots.

Fixes #156

---
*PR created automatically by Jules for task [15084962108826709486](https://jules.google.com/task/15084962108826709486) started by @username-anthony-is-not-available*