### PR TITLE
Enhance Prometheus Metrics Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Enhance Prometheus metrics with `miner_info`, `miner_uptime`, and `miner_api_up`.
+- Add `worker` label to all Prometheus metrics for better multi-rig support.
 - Add 'Eco Mode' underclocking profiles for RTX 30/40 series GPUs.
 - Implement 'One-Click Multi-GPU' discovery in `start.sh` for both NVIDIA and AMD.
 - Add support for `MULTI_PROCESS` mining mode, running one miner process per GPU for improved isolation and stability.

--- a/README.md
+++ b/README.md
@@ -267,6 +267,19 @@ The image includes a built-in Prometheus exporter that provides key performance 
 -   **URL:** `http://<your-docker-host>:4455/metrics`
 -   **Format:** Prometheus Text-Based
 
+### **Key Metrics**
+
+The exporter provides the following metrics, all labeled with `worker` for easy multi-rig aggregation:
+
+- `miner_info`: Static information including `miner` type and `version`.
+- `miner_hashrate`: Total rig hashrate in MH/s.
+- `miner_uptime`: Miner session uptime in seconds.
+- `miner_api_up`: Status of the miner API (1 for UP, 0 for DOWN).
+- `miner_total_power_draw`: Total power consumption in watts.
+- `miner_gpu_hashrate`: Per-GPU hashrate (labeled with `gpu` index).
+- `miner_gpu_temperature`: Per-GPU temperature in °C.
+- `miner_gpu_power_draw`: Per-GPU power draw in watts.
+
 This endpoint can be scraped by a Prometheus server to collect and store the metrics over time.
 
 ### Grafana Dashboard


### PR DESCRIPTION
Enhanced the Prometheus exporter to provide more comprehensive metrics and better support for multi-rig monitoring environments. Key additions include a `worker` label for all metrics, a `miner_info` metric for metadata, and status indicators like `miner_api_up` and `miner_uptime`.

Fixes #155

---
*PR created automatically by Jules for task [4506034431503524905](https://jules.google.com/task/4506034431503524905) started by @username-anthony-is-not-available*