### PR TITLE
Supporting Auto-Restart on CUDA Error Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Implement automated CUDA error detection and auto-restart functionality via `cuda_monitor.sh`.
+- New 'Auto-Restart on CUDA Error' configuration option in `setup.sh` and the web dashboard.
 - Add NVIDIA container runtime validation tool to `setup.sh` for easier first-time troubleshooting.
 - Enhance Prometheus metrics with `miner_info`, `miner_uptime`, and `miner_api_up`.
 - Add `worker` label to all Prometheus metrics for better multi-rig support.

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,12 +52,12 @@ COPY --from=builder /app/lolMiner /app/lolMiner
 COPY --from=builder /app/t-rex /app/t-rex
 
 # Copy scripts
-COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py ./
+COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh ./
 COPY dashboard.py .
 COPY templates/ templates/
 COPY static/ static/
 
-RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh && \
+RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh cuda_monitor.sh && \
     chown -R miner:miner /app
 
 EXPOSE 4444 4455 4456 5000

--- a/Dockerfile.amd
+++ b/Dockerfile.amd
@@ -47,12 +47,12 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY --from=builder /app/lolMiner /app/lolMiner
 
 # Copy scripts
-COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py ./
+COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh ./
 COPY dashboard.py .
 COPY templates/ templates/
 COPY static/ static/
 
-RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh && \
+RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh cuda_monitor.sh && \
     chown -R miner:miner /app
 
 EXPOSE 4444 4455 4456

--- a/cuda_monitor.sh
+++ b/cuda_monitor.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# cuda_monitor.sh - Background monitor for CUDA errors in miner logs
+
+LOG_FILE="miner.log"
+
+# Wait for log file to be created by the miner
+echo "Waiting for $LOG_FILE to be created..."
+while [ ! -f "$LOG_FILE" ]; do
+  sleep 2
+done
+
+echo "Starting CUDA error monitor on $LOG_FILE..."
+
+# Pattern to match common CUDA errors across different miners
+# Case-insensitive match for:
+# - out of memory
+# - illegal instruction
+# - CUDA error
+# - GPU fell off the bus
+# - an illegal memory access was encountered
+ERROR_PATTERN="out of memory|illegal instruction|CUDA error|GPU fell off the bus|an illegal memory access was encountered"
+
+tail -F "$LOG_FILE" | while read -r line; do
+  if echo "$line" | grep -Ei "$ERROR_PATTERN" > /dev/null; then
+    echo "$(date): CRITICAL: CUDA error detected: $line"
+    echo "$(date): Triggering auto-restart..."
+    # Give it a second to log the error fully
+    sleep 1
+    ./restart.sh
+    # Monitor exits after triggering restart as the whole container will restart
+    exit 0
+  fi
+done

--- a/setup.sh
+++ b/setup.sh
@@ -221,6 +221,15 @@ else
     TELEGRAM_ENABLE="false"
 fi
 
+# 11. Auto-Restart on CUDA Error
+echo -e "\n${GREEN}11. Auto-Restart on CUDA Error${NC}"
+read -p "Enable Auto-Restart on CUDA error detection? (y/n) [n]: " CUDA_RESTART_CHOICE
+if [[ "$CUDA_RESTART_CHOICE" =~ ^[Yy]$ ]]; then
+    AUTO_RESTART_ON_CUDA_ERROR="true"
+else
+    AUTO_RESTART_ON_CUDA_ERROR="false"
+fi
+
 # Generate .env file
 echo -e "\n${BLUE}Generating .env file...${NC}"
 cat <<EOF > .env
@@ -249,6 +258,9 @@ AUTO_PROFIT_SWITCHING=${AUTO_PROFIT_SWITCHING}
 
 # Telegram Notifications
 TELEGRAM_ENABLE=${TELEGRAM_ENABLE}
+
+# Auto-Restart on CUDA Error
+AUTO_RESTART_ON_CUDA_ERROR=${AUTO_RESTART_ON_CUDA_ERROR}
 EOF
 
 if [ "$TELEGRAM_ENABLE" == "true" ]; then

--- a/start.sh
+++ b/start.sh
@@ -127,6 +127,11 @@ uvicorn dashboard:sio_app --host 0.0.0.0 --port 5000 &
 # Start the profit switcher in the background
 python3 profit_switcher.py &
 
+# Start CUDA error monitor if enabled
+if [ "$AUTO_RESTART_ON_CUDA_ERROR" = "true" ]; then
+  ./cuda_monitor.sh &
+fi
+
 # Start GPU monitoring in the background based on available tools
 if command -v nvidia-smi &> /dev/null; then
   (

--- a/templates/config.html
+++ b/templates/config.html
@@ -76,6 +76,12 @@
                 <label for="gpu_power_limit">GPU Power Limit</label>
                 <input type="number" id="gpu_power_limit" name="GPU_POWER_LIMIT">
             </div>
+            <hr>
+            <h2>Stability & Maintenance</h2>
+            <div class="form-group">
+                <label for="auto_restart_on_cuda_error">Auto-Restart on CUDA Error</label>
+                <input type="checkbox" id="auto_restart_on_cuda_error" name="AUTO_RESTART_ON_CUDA_ERROR">
+            </div>
             <button type="submit">Save</button>
         </form>
         <button id="restart-miner">Restart Miner</button>
@@ -101,6 +107,7 @@
                     document.getElementById('gpu_clock_offset').value = data.GPU_CLOCK_OFFSET || 0;
                     document.getElementById('gpu_mem_offset').value = data.GPU_MEM_OFFSET || 0;
                     document.getElementById('gpu_power_limit').value = data.GPU_POWER_LIMIT || 0;
+                    document.getElementById('auto_restart_on_cuda_error').checked = data.AUTO_RESTART_ON_CUDA_ERROR === 'true';
                 });
             // Handle form submission
             document.getElementById('config-form').addEventListener('submit', function(event) {
@@ -113,6 +120,7 @@
                 data['APPLY_OC'] = document.getElementById('apply_oc').checked;
                 data['ECO_MODE'] = document.getElementById('eco_mode').checked;
                 data['AUTO_PROFIT_SWITCHING'] = document.getElementById('auto_profit_switching').checked;
+                data['AUTO_RESTART_ON_CUDA_ERROR'] = document.getElementById('auto_restart_on_cuda_error').checked;
                 fetch('/api/config', {
                     method: 'POST',
                     headers: {

--- a/tests/test_cuda_monitor.sh
+++ b/tests/test_cuda_monitor.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# tests/test_cuda_monitor.sh
+
+# Setup
+TEST_LOG="test_miner.log"
+MONITOR_SCRIPT="./cuda_monitor.sh"
+
+echo "Setting up CUDA monitor test..."
+
+# Mock restart.sh to avoid killing PID 1 during test
+cat <<EOF > mock_restart.sh
+#!/bin/bash
+echo "RESTART_TRIGGERED" > restart_triggered.txt
+EOF
+chmod +x mock_restart.sh
+
+# Create a test version of the monitor script with mocked components
+# We use sed to replace the log file and the restart script call
+sed -e "s|LOG_FILE=\"miner.log\"|LOG_FILE=\"$TEST_LOG\"|" \
+    -e "s|./restart.sh|./mock_restart.sh|" \
+    "$MONITOR_SCRIPT" > test_cuda_monitor.sh
+chmod +x test_cuda_monitor.sh
+
+# Start with a fresh log file
+rm -f "$TEST_LOG"
+touch "$TEST_LOG"
+
+# Run monitor in background
+./test_cuda_monitor.sh &
+MONITOR_PID=$!
+
+echo "Monitor started with PID $MONITOR_PID. Waiting for initialization..."
+sleep 2
+
+# Test Case 1: Normal lines should NOT trigger restart
+echo "Normal: Miner started" >> "$TEST_LOG"
+echo "Normal: GPU 0: 45 MH/s" >> "$TEST_LOG"
+sleep 1
+
+if [ -f restart_triggered.txt ]; then
+    echo "FAILURE: Restart triggered on normal log lines!"
+    kill $MONITOR_PID 2>/dev/null || true
+    rm -f "$TEST_LOG" mock_restart.sh restart_triggered.txt test_cuda_monitor.sh
+    exit 1
+fi
+
+# Test Case 2: CUDA error should trigger restart
+echo "Testing 'out of memory' detection..."
+echo "Error: CUDA error: out of memory" >> "$TEST_LOG"
+
+# Wait for monitor to react
+sleep 3
+
+if [ -f restart_triggered.txt ] && [ "$(cat restart_triggered.txt)" = "RESTART_TRIGGERED" ]; then
+    echo "SUCCESS: 'out of memory' detected and restart triggered!"
+else
+    echo "FAILURE: 'out of memory' not detected."
+    kill $MONITOR_PID 2>/dev/null || true
+    rm -f "$TEST_LOG" mock_restart.sh restart_triggered.txt test_cuda_monitor.sh
+    exit 1
+fi
+
+# Reset trigger file for next case
+rm -f restart_triggered.txt
+
+# Test Case 3: Illegal instruction detection
+# We need to restart the monitor because it exits after first detection
+./test_cuda_monitor.sh &
+MONITOR_PID=$!
+sleep 2
+
+echo "Testing 'illegal instruction' detection..."
+echo "CRITICAL: illegal instruction encountered" >> "$TEST_LOG"
+sleep 3
+
+if [ -f restart_triggered.txt ] && [ "$(cat restart_triggered.txt)" = "RESTART_TRIGGERED" ]; then
+    echo "SUCCESS: 'illegal instruction' detected and restart triggered!"
+else
+    echo "FAILURE: 'illegal instruction' not detected."
+    kill $MONITOR_PID 2>/dev/null || true
+    rm -f "$TEST_LOG" mock_restart.sh restart_triggered.txt test_cuda_monitor.sh
+    exit 1
+fi
+
+# Cleanup
+kill $MONITOR_PID 2>/dev/null || true
+rm -f "$TEST_LOG" mock_restart.sh restart_triggered.txt test_cuda_monitor.sh
+echo "All CUDA monitor tests passed!"
+exit 0

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -32,6 +32,7 @@ fi
 # Telegram Token: MyToken
 # Telegram ID: MyID
 # Telegram Threshold: 600
+# Auto-Restart: y
 # Start now: n
 ./setup.sh <<EOF
 MyTestWallet
@@ -55,6 +56,7 @@ y
 MyToken
 MyID
 600
+y
 n
 EOF
 
@@ -93,6 +95,7 @@ check_var "TELEGRAM_ENABLE=true"
 check_var "TELEGRAM_BOT_TOKEN=MyToken"
 check_var "TELEGRAM_CHAT_ID=MyID"
 check_var "TELEGRAM_NOTIFY_THRESHOLD=600"
+check_var "AUTO_RESTART_ON_CUDA_ERROR=true"
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "setup.sh test 1 PASSED"
@@ -101,6 +104,7 @@ else
 fi
 
 rm .env
+EXIT_CODE=0
 
 echo "Running setup.sh test 2 (AMD, Defaults)..."
 # Wallet: AmdWallet
@@ -112,6 +116,7 @@ echo "Running setup.sh test 2 (AMD, Defaults)..."
 # Extra Args: empty
 # Profit Switching: n
 # Telegram: n
+# Auto-Restart: n
 # Start now: n
 ./setup.sh <<EOF
 AmdWallet
@@ -121,6 +126,7 @@ AmdWallet
 2
 
 
+n
 n
 n
 n
@@ -135,6 +141,7 @@ check_var "GPU_DEVICES=AUTO"
 check_var "APPLY_OC=false"
 check_var "AUTO_PROFIT_SWITCHING=false"
 check_var "TELEGRAM_ENABLE=false"
+check_var "AUTO_RESTART_ON_CUDA_ERROR=false"
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo "setup.sh test 2 PASSED"


### PR DESCRIPTION
This feature implements automated CUDA error detection by tailing the miner logs. When critical errors such as 'out of memory' or 'illegal instruction' are detected, the system triggers a container restart to recover the mining process. This is especially useful for 24/7 mining rigs that may encounter occasional driver or hardware-related errors. The feature is opt-in and can be configured through the interactive setup script or the web dashboard's configuration page.

Fixes #153

---
*PR created automatically by Jules for task [6891497282405991722](https://jules.google.com/task/6891497282405991722) started by @username-anthony-is-not-available*