### PR TITLE
Add GPU-Specific Performance Tuning Profiles for NVIDIA 30/40 Series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rig-wide metrics (Total Power Draw, Average Temperature) in the web dashboard.
 - Automated T-Rex version discovery in `setup.sh`.
 - WoolyPooly pool support in `setup.sh`.
-- New GPU tuning profiles for RTX 3060 Ti, 3090, 4070, and 4090 in `gpu_profiles.json`.
+- Comprehensive GPU tuning profiles for NVIDIA 30/40 series (3050, 3060/Ti, 3070/Ti, 3080/Ti, 3090/Ti, 4060/Ti, 4070/Super/Ti/Ti Super, 4080/Super, 4090) in `gpu_profiles.json`.
 - `miner_total_shares_accepted` and `miner_total_shares_rejected` Prometheus metrics.
 - Multi-miner support (lolMiner and T-Rex) in the web dashboard via a normalization layer.
 - Hardware-level GPU metrics (Temperature, Power Draw) in the dashboard using `nvidia-smi` and `rocm-smi`.

--- a/gpu_profiles.json
+++ b/gpu_profiles.json
@@ -1,43 +1,13 @@
 {
-  "RTX 3060": {
-    "GPU_CLOCK_OFFSET": -200,
-    "GPU_MEM_OFFSET": 1200,
-    "GPU_POWER_LIMIT": 120
-  },
-  "RTX 3060 (Eco)": {
-    "GPU_CLOCK_OFFSET": -300,
-    "GPU_MEM_OFFSET": 1200,
-    "GPU_POWER_LIMIT": 90
-  },
-  "RTX 3070": {
-    "GPU_CLOCK_OFFSET": -200,
-    "GPU_MEM_OFFSET": 1300,
-    "GPU_POWER_LIMIT": 130
-  },
-  "RTX 3070 (Eco)": {
-    "GPU_CLOCK_OFFSET": -300,
-    "GPU_MEM_OFFSET": 1300,
-    "GPU_POWER_LIMIT": 110
-  },
-  "RTX 3080": {
+  "RTX 3090 Ti": {
     "GPU_CLOCK_OFFSET": -200,
     "GPU_MEM_OFFSET": 1500,
-    "GPU_POWER_LIMIT": 240
+    "GPU_POWER_LIMIT": 350
   },
-  "RTX 3080 (Eco)": {
+  "RTX 3090 Ti (Eco)": {
     "GPU_CLOCK_OFFSET": -300,
     "GPU_MEM_OFFSET": 1500,
-    "GPU_POWER_LIMIT": 190
-  },
-  "RTX 3060 Ti": {
-    "GPU_CLOCK_OFFSET": -200,
-    "GPU_MEM_OFFSET": 1200,
-    "GPU_POWER_LIMIT": 130
-  },
-  "RTX 3060 Ti (Eco)": {
-    "GPU_CLOCK_OFFSET": -300,
-    "GPU_MEM_OFFSET": 1200,
-    "GPU_POWER_LIMIT": 100
+    "GPU_POWER_LIMIT": 280
   },
   "RTX 3090": {
     "GPU_CLOCK_OFFSET": -200,
@@ -49,15 +19,75 @@
     "GPU_MEM_OFFSET": 1000,
     "GPU_POWER_LIMIT": 250
   },
-  "RTX 4070": {
+  "RTX 3080 Ti": {
     "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 250
+  },
+  "RTX 3080 Ti (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 210
+  },
+  "RTX 3080": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 240
+  },
+  "RTX 3080 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 190
+  },
+  "RTX 3070 Ti": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 180
+  },
+  "RTX 3070 Ti (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
     "GPU_MEM_OFFSET": 1300,
     "GPU_POWER_LIMIT": 150
   },
-  "RTX 4070 (Eco)": {
+  "RTX 3070": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 130
+  },
+  "RTX 3070 (Eco)": {
     "GPU_CLOCK_OFFSET": -300,
     "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 110
+  },
+  "RTX 3060 Ti": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1200,
+    "GPU_POWER_LIMIT": 130
+  },
+  "RTX 3060 Ti (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1200,
+    "GPU_POWER_LIMIT": 100
+  },
+  "RTX 3060": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1200,
     "GPU_POWER_LIMIT": 120
+  },
+  "RTX 3060 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1200,
+    "GPU_POWER_LIMIT": 90
+  },
+  "RTX 3050": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1000,
+    "GPU_POWER_LIMIT": 90
+  },
+  "RTX 3050 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1000,
+    "GPU_POWER_LIMIT": 70
   },
   "RTX 4090": {
     "GPU_CLOCK_OFFSET": -200,
@@ -68,5 +98,85 @@
     "GPU_CLOCK_OFFSET": -300,
     "GPU_MEM_OFFSET": 1500,
     "GPU_POWER_LIMIT": 280
+  },
+  "RTX 4080 Super": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 270
+  },
+  "RTX 4080 Super (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 220
+  },
+  "RTX 4080": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 250
+  },
+  "RTX 4080 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1500,
+    "GPU_POWER_LIMIT": 200
+  },
+  "RTX 4070 Ti Super": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 220
+  },
+  "RTX 4070 Ti Super (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 180
+  },
+  "RTX 4070 Ti": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 200
+  },
+  "RTX 4070 Ti (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 160
+  },
+  "RTX 4070 Super": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 170
+  },
+  "RTX 4070 Super (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 140
+  },
+  "RTX 4070": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 150
+  },
+  "RTX 4070 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1300,
+    "GPU_POWER_LIMIT": 120
+  },
+  "RTX 4060 Ti": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1200,
+    "GPU_POWER_LIMIT": 130
+  },
+  "RTX 4060 Ti (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1200,
+    "GPU_POWER_LIMIT": 110
+  },
+  "RTX 4060": {
+    "GPU_CLOCK_OFFSET": -200,
+    "GPU_MEM_OFFSET": 1200,
+    "GPU_POWER_LIMIT": 100
+  },
+  "RTX 4060 (Eco)": {
+    "GPU_CLOCK_OFFSET": -300,
+    "GPU_MEM_OFFSET": 1200,
+    "GPU_POWER_LIMIT": 80
   }
 }


### PR DESCRIPTION
Added a comprehensive set of GPU-specific performance tuning profiles for NVIDIA 30 and 40 series cards to `gpu_profiles.json`. This includes optimized settings for both maximum performance and maximum efficiency (Eco mode) for models such as the RTX 3050, 3070 Ti, 3080 Ti, 3090 Ti, 4060, 4060 Ti, 4070 Super, 4070 Ti, 4070 Ti Super, 4080, and 4080 Super. The database was also re-ordered to ensure correct auto-detection of specific hardware variants. All tests passed, and the configuration tool (`setup.sh`) now correctly reflects the new options.

Fixes #152

---
*PR created automatically by Jules for task [12999688517516121367](https://jules.google.com/task/12999688517516121367) started by @username-anthony-is-not-available*