### PR TITLE
Add Ergo Node health check and integration

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -234,6 +234,18 @@ else
     AUTO_RESTART_ON_CUDA_ERROR="false"
 fi
 
+# 12. Ergo Node Integration
+echo -e "\n${GREEN}12. Ergo Node Integration${NC}"
+read -p "Pause mining if local Ergo node is out of sync? (y/n) [n]: " NODE_SYNC_CHOICE
+if [[ "$NODE_SYNC_CHOICE" =~ ^[Yy]$ ]]; then
+    CHECK_NODE_SYNC="true"
+    read -p "Enter Ergo Node API URL [http://localhost:9053]: " NODE_URL
+    NODE_URL=${NODE_URL:-http://localhost:9053}
+else
+    CHECK_NODE_SYNC="false"
+    NODE_URL=""
+fi
+
 # Generate .env file
 echo -e "\n${BLUE}Generating .env file...${NC}"
 cat <<EOF > .env
@@ -267,6 +279,10 @@ TELEGRAM_ENABLE=${TELEGRAM_ENABLE}
 
 # Auto-Restart on CUDA Error
 AUTO_RESTART_ON_CUDA_ERROR=${AUTO_RESTART_ON_CUDA_ERROR}
+
+# Ergo Node Integration
+CHECK_NODE_SYNC=${CHECK_NODE_SYNC}
+NODE_URL=${NODE_URL}
 EOF
 
 if [ "$TELEGRAM_ENABLE" == "true" ]; then

--- a/templates/config.html
+++ b/templates/config.html
@@ -130,6 +130,16 @@
                 <label for="auto_restart_on_cuda_error">Auto-Restart on CUDA Error</label>
                 <input type="checkbox" id="auto_restart_on_cuda_error" name="AUTO_RESTART_ON_CUDA_ERROR">
             </div>
+            <hr>
+            <h2>Ergo Node Integration</h2>
+            <div class="form-group">
+                <label for="check_node_sync">Pause mining if local Ergo node is out of sync</label>
+                <input type="checkbox" id="check_node_sync" name="CHECK_NODE_SYNC">
+            </div>
+            <div class="form-group">
+                <label for="node_url">Ergo Node API URL</label>
+                <input type="text" id="node_url" name="NODE_URL" placeholder="http://localhost:9053">
+            </div>
             <button type="submit">Save</button>
         </form>
         <button id="restart-miner">Restart Miner</button>
@@ -158,6 +168,8 @@
                     document.getElementById('gpu_mem_offset').value = data.GPU_MEM_OFFSET || 0;
                     document.getElementById('gpu_power_limit').value = data.GPU_POWER_LIMIT || 0;
                     document.getElementById('auto_restart_on_cuda_error').checked = data.AUTO_RESTART_ON_CUDA_ERROR === 'true';
+                    document.getElementById('check_node_sync').checked = data.CHECK_NODE_SYNC === 'true';
+                    document.getElementById('node_url').value = data.NODE_URL || '';
 
                     // Dual Mining
                     document.getElementById('dual_algo').value = data.DUAL_ALGO || '';
@@ -186,6 +198,8 @@
                 data['PROFIT_SWITCHING_INTERVAL'] = document.getElementById('profit_switching_interval').value;
                 data['AUTO_RESTART_ON_CUDA_ERROR'] = document.getElementById('auto_restart_on_cuda_error').checked;
                 data['TELEGRAM_ENABLE'] = document.getElementById('telegram_enable').checked;
+                data['CHECK_NODE_SYNC'] = document.getElementById('check_node_sync').checked;
+                data['NODE_URL'] = document.getElementById('node_url').value;
 
                 fetch('/api/config', {
                     method: 'POST',

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,6 +43,11 @@
                 <h2>Efficiency</h2>
                 <p id="total-efficiency">-- MH/W</p>
             </div>
+            <div id="node-status-card" class="stat-card" style="display: none;">
+                <h2>Ergo Node</h2>
+                <p id="node-sync-status">--</p>
+                <small id="node-height">Height: -- / --</small>
+            </div>
         </div>
 
         <h2>System Information</h2>
@@ -163,6 +168,25 @@
                 document.getElementById('total-dual-hashrate').innerText = `${data.total_dual_hashrate.toFixed(2)} MH/s`;
             } else {
                 document.getElementById('dual-hashrate-card').style.display = 'none';
+            }
+
+            if (data.node_status && data.node_status.enabled) {
+                document.getElementById('node-status-card').style.display = 'block';
+                const nodeStatus = data.node_status;
+                const syncEl = document.getElementById('node-sync-status');
+
+                if (nodeStatus.is_synced) {
+                    syncEl.innerText = 'Synced';
+                    syncEl.style.color = '#4caf50';
+                } else {
+                    syncEl.innerText = nodeStatus.error ? 'Error' : 'Syncing...';
+                    syncEl.style.color = '#ff9800';
+                    if (nodeStatus.error) syncEl.style.color = '#f44336';
+                }
+
+                document.getElementById('node-height').innerText = `Height: ${nodeStatus.full_height || 0} / ${nodeStatus.headers_height || 0}`;
+            } else {
+                document.getElementById('node-status-card').style.display = 'none';
             }
 
             if (data.uptime !== undefined) {


### PR DESCRIPTION
This feature adds integration with a local Ergo node for solo miners. It ensures that the miner only runs when the node is fully synchronized, preventing wasted power and effort on stale blocks.

Key changes:
- `miner_api.py`: New `get_node_status()` function that queries the Ergo node API.
- `start.sh`: A new wait loop that blocks miner startup if node sync is required but not yet achieved.
- `healthcheck.sh`: Enhanced to detect out-of-sync nodes while mining and trigger a container restart to enter the wait state.
- Web Dashboard: New configuration fields and a dedicated status card for monitoring node health.
- Setup: Interactive configuration for node URL and sync check toggle.

Fixes #128

---
*PR created automatically by Jules for task [12934050295596002365](https://jules.google.com/task/12934050295596002365) started by @username-anthony-is-not-available*