### PR TITLE
Standardize 'Healthcheck' using Python metrics

### DIFF
--- a/tests/test_healthcheck.sh
+++ b/tests/test_healthcheck.sh
@@ -24,6 +24,9 @@ export PATH="$MOCK_BIN_DIR:$PATH"
 
 cat > "$MOCK_BIN_DIR/curl" <<EOF
 #!/bin/bash
+if [ -f /tmp/curl_fail ]; then
+    exit 1
+fi
 cat /tmp/mock_api_response
 EOF
 chmod +x "$MOCK_BIN_DIR/curl"
@@ -31,6 +34,7 @@ chmod +x "$MOCK_BIN_DIR/curl"
 cat > "$MOCK_BIN_DIR/pgrep" <<EOF
 #!/bin/bash
 if [ -f /tmp/mock_process_running ]; then
+    echo "1234" # Dummy PID
     exit 0
 else
     exit 1
@@ -77,44 +81,61 @@ function cleanup() {
     if [ -f "restart.sh.bak" ]; then
         mv restart.sh.bak restart.sh
     fi
-    rm -f /tmp/mock_api_response /tmp/mock_process_running /tmp/restart_called /tmp/test_output "$HEALTHCHECK_STATE_FILE"
+    rm -f /tmp/mock_api_response /tmp/mock_process_running /tmp/restart_called /tmp/test_output "$HEALTHCHECK_STATE_FILE" /tmp/curl_fail
+}
+
+function mock_metrics() {
+    local hashrate=$1
+    local api_up=${2:-1.0}
+    local gpu_count=${3:-2.0}
+    local accepted=${4:-100.0}
+    local rejected=${5:-0.0}
+    local miner=${6:-lolminer}
+    local node_synced=${7:-1.0}
+
+    cat > /tmp/mock_api_response <<EOF
+miner_hashrate{worker="test"} $hashrate
+miner_api_up{worker="test"} $api_up
+miner_gpu_count{worker="test"} $gpu_count
+miner_total_shares_accepted{worker="test"} $accepted
+miner_total_shares_rejected{worker="test"} $rejected
+miner_node_synced{worker="test"} $node_synced
+miner_info{miner="$miner",version="1.0",worker="test"} 1.0
+EOF
 }
 
 # --- Test Cases ---
 
 # 1. Healthy lolminer
-export MINER=lolminer
 export GPU_DEVICES=AUTO
 touch /tmp/mock_process_running
-echo '{"Total_Performance": [100.5], "GPUs": [{}, {}]}' > /tmp/mock_api_response
+mock_metrics 100.5 1.0 2.0 100 0 lolminer 1.0
 run_test "Healthy lolminer" 0 "no"
 
 # 2. Healthy t-rex
-export MINER=t-rex
-echo '{"hashrate": 50000000, "gpus": [{}, {}]}' > /tmp/mock_api_response
+mock_metrics 50.0 1.0 2.0 100 0 t-rex 1.0
 run_test "Healthy t-rex" 0 "no"
 
-# 3. lolminer 0 hashrate (Grace period starts)
-export MINER=lolminer
-echo '{"Total_Performance": [0], "GPUs": [{}, {}]}' > /tmp/mock_api_response
-run_test "lolminer 0 hashrate (start grace)" 0 "no"
+# 3. 0 hashrate (Grace period starts)
+mock_metrics 0 1.0 2.0 100 0 lolminer 1.0
+run_test "0 hashrate (start grace)" 0 "no"
 if [ ! -f "$HEALTHCHECK_STATE_FILE" ]; then
     echo "FAILED: State file not created"
     cleanup
     exit 1
 fi
 
-# 4. lolminer 0 hashrate (Within grace period)
+# 4. 0 hashrate (Within grace period)
 echo $(($(date +%s) - 120)) > "$HEALTHCHECK_STATE_FILE"
-run_test "lolminer 0 hashrate (within grace)" 0 "no"
+run_test "0 hashrate (within grace)" 0 "no"
 
-# 5. lolminer 0 hashrate (After grace period)
+# 5. 0 hashrate (After grace period)
 echo $(($(date +%s) - 360)) > "$HEALTHCHECK_STATE_FILE"
-run_test "lolminer 0 hashrate (after grace)" 1 "yes"
+run_test "0 hashrate (after grace)" 1 "yes"
 
 # 6. Recovery during grace period
 echo $(($(date +%s) - 120)) > "$HEALTHCHECK_STATE_FILE"
-echo '{"Total_Performance": [100.5], "GPUs": [{}, {}]}' > /tmp/mock_api_response
+mock_metrics 100.5 1.0 2.0 100 0 lolminer 1.0
 run_test "Recovery during grace period" 0 "no"
 if [ -f "$HEALTHCHECK_STATE_FILE" ]; then
     echo "FAILED: State file not removed after recovery"
@@ -122,82 +143,40 @@ if [ -f "$HEALTHCHECK_STATE_FILE" ]; then
     exit 1
 fi
 
-# 7. Process not running (immediate failure)
-rm /tmp/mock_process_running
-run_test "Process not running" 1 "yes"
-touch /tmp/mock_process_running
-
-# 8. GPU count mismatch (lolminer)
-export MINER=lolminer
+# 7. GPU count mismatch
 export GPU_DEVICES="0,1"
-echo '{"Total_Performance": [100.5], "GPUs": [{}]}' > /tmp/mock_api_response
-run_test "GPU count mismatch (lolminer)" 1 "yes"
+mock_metrics 100.5 1.0 1.0 100 0 lolminer 1.0 # Only 1 GPU reported
+run_test "GPU count mismatch" 1 "yes"
 
-# 9. GPU count match (lolminer)
+# 8. GPU count match
 export GPU_DEVICES="0,1"
-echo '{"Total_Performance": [100.5], "GPUs": [{}, {}]}' > /tmp/mock_api_response
-run_test "GPU count match (lolminer)" 0 "no"
+mock_metrics 100.5 1.0 2.0 100 0 lolminer 1.0
+run_test "GPU count match" 0 "no"
 
-# 10. GPU count mismatch (t-rex)
-export MINER=t-rex
-export GPU_DEVICES="0,1,2"
-echo '{"hashrate": 50000000, "gpus": [{}, {}]}' > /tmp/mock_api_response
-run_test "GPU count mismatch (t-rex)" 1 "yes"
-
-# 11. Multi-process healthy
-export MULTI_PROCESS=true
-export GPU_DEVICES="0,1"
-export MINER=lolminer
-# We need to mock pgrep to return multiple lines for MULTI_PROCESS check
-cat > "$MOCK_BIN_DIR/pgrep" <<EOF
-#!/bin/bash
-if [ -f /tmp/mock_process_running ]; then
-    echo "123"
-    echo "456"
-    exit 0
-else
-    exit 1
-fi
-EOF
-chmod +x "$MOCK_BIN_DIR/pgrep"
-echo '{"Total_Performance": [50.0], "GPUs": [{}]}' > /tmp/mock_api_response
-run_test "Multi-process healthy" 0 "no"
-
-# 12. Multi-process process count mismatch
-cat > "$MOCK_BIN_DIR/pgrep" <<EOF
-#!/bin/bash
-if [ -f /tmp/mock_process_running ]; then
-    echo "123"
-    exit 0
-else
-    exit 1
-fi
-EOF
-chmod +x "$MOCK_BIN_DIR/pgrep"
-run_test "Multi-process process count mismatch" 1 "yes"
-
-# 13. High rejected share ratio (lolminer)
-export MULTI_PROCESS=false
+# 9. High rejected share ratio
 export GPU_DEVICES=AUTO
-export MINER=lolminer
-cat > "$MOCK_BIN_DIR/pgrep" <<EOF
-#!/bin/bash
-if [ -f /tmp/mock_process_running ]; then
-    echo "123"
-    exit 0
-else
-    exit 1
-fi
-EOF
-chmod +x "$MOCK_BIN_DIR/pgrep"
 # 10 accepted, 11 rejected = 21 total, > 50% reject ratio
-echo '{"Total_Performance": [100.5], "GPUs": [{"Accepted_Shares": 10, "Rejected_Shares": 11}]}' > /tmp/mock_api_response
-run_test "High rejected share ratio (lolminer)" 1 "yes"
+mock_metrics 100.5 1.0 2.0 10 11 lolminer 1.0
+run_test "High rejected share ratio" 1 "yes"
 
-# 14. Normal rejected share ratio (lolminer)
+# 10. Normal rejected share ratio
 # 20 accepted, 1 rejected = 21 total, ~4.7% reject ratio
-echo '{"Total_Performance": [100.5], "GPUs": [{"Accepted_Shares": 20, "Rejected_Shares": 1}]}' > /tmp/mock_api_response
-run_test "Normal rejected share ratio (lolminer)" 0 "no"
+mock_metrics 100.5 1.0 2.0 20 1 lolminer 1.0
+run_test "Normal rejected share ratio" 0 "no"
+
+# 11. Node out of sync while mining
+mock_metrics 100.5 1.0 2.0 100 0 lolminer 0.0 # Node not synced
+touch /tmp/mock_process_running # Miner is running
+run_test "Node out of sync while mining" 1 "yes"
+
+# 12. Node out of sync but miner not running (Waiting)
+mock_metrics 100.5 1.0 2.0 100 0 lolminer 0.0 # Node not synced
+rm /tmp/mock_process_running # Miner NOT running
+run_test "Node out of sync while waiting" 0 "no"
+
+# 13. Metrics server unreachable
+touch /tmp/curl_fail
+run_test "Metrics server unreachable" 0 "no"
 
 cleanup
 echo "All healthcheck tests passed!"


### PR DESCRIPTION
This change standardizes the health check mechanism by utilizing the existing Python metrics server. By querying aggregated metrics instead of raw miner APIs, the health check becomes more robust, accurately reflects rig-wide hashrate even in multi-process mode, and avoids code duplication for miner-specific API parsing. Key metrics for hashrate, GPU count, and node sync status are now centralized, and the health check script is simplified into a lightweight wrapper around these metrics.

Fixes #127

---
*PR created automatically by Jules for task [17410580944413406451](https://jules.google.com/task/17410580944413406451) started by @username-anthony-is-not-available*