### PR TITLE
Support Docker Secrets for Pool Wallet Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,24 @@ docker run --user 1000:1000 ...
 ```
 *Note: If started as a non-root user, the automatic overclocking feature will be skipped as it requires root privileges.*
 
+### Docker Secrets
+For improved security, you can use Docker secrets to provide sensitive information like wallet addresses instead of including them in plain text in your `docker-compose.yml` or `.env` file.
+
+The following secrets are supported:
+- `WALLET_ADDRESS`: Your primary Ergo wallet address.
+- `DUAL_WALLET`: Your wallet address for the second coin (if dual mining).
+
+To use secrets in Docker Compose:
+```yaml
+services:
+  nvidia:
+    # ...
+    secrets:
+      - WALLET_ADDRESS
+secrets:
+  WALLET_ADDRESS:
+    file: ./wallet_address.txt
+```
 
 ### GPU Tuning Profiles
 

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Support Docker secrets for sensitive variables
+load_secret() {
+    local var=$1
+    local file="/run/secrets/$var"
+    if [ -f "$file" ]; then
+        if [ -z "${!var}" ]; then
+            export "$var"=$(cat "$file" | tr -d '\r\n')
+            echo "Loaded $var from secret."
+        fi
+    fi
+}
+
+load_secret WALLET_ADDRESS
+load_secret DUAL_WALLET
+
 # Handle privilege dropping if running as root
 if [ "$(id -u)" = '0' ]; then
   echo "Running as root. Ensuring /app ownership and applying OC settings..."

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -170,7 +170,7 @@ def main():
         with st.form("config_form"):
             # Group settings
             st.subheader("Wallet & Pool")
-            wallet = st.text_input("Wallet Address", value=config.get('WALLET_ADDRESS', ''))
+            wallet = st.text_input("Wallet Address", value=os.getenv('WALLET_ADDRESS', config.get('WALLET_ADDRESS', '')))
             pool = st.text_input("Pool Address", value=config.get('POOL_ADDRESS', ''))
             worker = st.text_input("Worker Name", value=config.get('WORKER_NAME', 'ergo-miner'))
 

--- a/tests/test_secrets.sh
+++ b/tests/test_secrets.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# tests/test_secrets.sh
+# Test script to verify Docker secrets loading logic in start.sh
+
+set -e
+
+# Mock /run/secrets
+MOCK_SECRETS_DIR=$(mktemp -d)
+echo "secret_wallet_address" > "$MOCK_SECRETS_DIR/WALLET_ADDRESS"
+echo "secret_dual_wallet" > "$MOCK_SECRETS_DIR/DUAL_WALLET"
+
+# Function from start.sh (adapted for test)
+load_secret() {
+    local var=$1
+    local file="$MOCK_SECRETS_DIR/$var"
+    if [ -f "$file" ]; then
+        if [ -z "${!var}" ]; then
+            export "$var"=$(cat "$file" | tr -d '\r\n')
+            echo "Loaded $var from secret: ${!var}"
+        else
+            echo "$var is already set, skipping secret."
+        fi
+    fi
+}
+
+echo "Running Docker Secrets Tests..."
+
+# Test 1: Load from secret when env var is empty
+unset WALLET_ADDRESS
+load_secret WALLET_ADDRESS
+if [ "$WALLET_ADDRESS" == "secret_wallet_address" ]; then
+    echo "✅ Test 1 Passed: WALLET_ADDRESS loaded from secret"
+else
+    echo "❌ Test 1 Failed: WALLET_ADDRESS is '$WALLET_ADDRESS', expected 'secret_wallet_address'"
+    exit 1
+fi
+
+# Test 2: Do not override if env var is already set
+export DUAL_WALLET="env_dual_wallet"
+load_secret DUAL_WALLET
+if [ "$DUAL_WALLET" == "env_dual_wallet" ]; then
+    echo "✅ Test 2 Passed: DUAL_WALLET not overridden by secret"
+else
+    echo "❌ Test 2 Failed: DUAL_WALLET is '$DUAL_WALLET', expected 'env_dual_wallet'"
+    exit 1
+fi
+
+# Test 3: Load DUAL_WALLET from secret when empty
+unset DUAL_WALLET
+load_secret DUAL_WALLET
+if [ "$DUAL_WALLET" == "secret_dual_wallet" ]; then
+    echo "✅ Test 3 Passed: DUAL_WALLET loaded from secret"
+else
+    echo "❌ Test 3 Failed: DUAL_WALLET is '$DUAL_WALLET', expected 'secret_dual_wallet'"
+    exit 1
+fi
+
+# Cleanup
+rm -rf "$MOCK_SECRETS_DIR"
+echo "All Docker Secrets tests passed!"


### PR DESCRIPTION
This PR implements support for Docker Secrets, allowing users to securely provide wallet addresses (WALLET_ADDRESS and DUAL_WALLET) without including them in plain text in docker-compose.yml or .env files.

Changes:
- Modified `start.sh` to check for secrets in `/run/secrets/` and export them if not already set in the environment.
- Updated the Streamlit dashboard configuration page to show the wallet address from the environment, ensuring values provided via secrets are visible.
- Updated `README.md` with instructions and examples on how to use Docker secrets.
- Included a new test script `tests/test_secrets.sh` to verify the implementation.

Verified with unit tests, E2E healthcheck tests, and manual frontend verification using Playwright screenshots.

Fixes #161

---
*PR created automatically by Jules for task [10562814566950228380](https://jules.google.com/task/10562814566950228380) started by @username-anthony-is-not-available*