### PR TITLE
Implement Hashrate Logging and Weekly Report Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Implement background hashrate logging to CSV and automated weekly report generation.
 - Implement E2E testing for the liveness probe (healthcheck) using a new `tests/mock_miner_api.py` server and `tests/test_healthcheck_e2e.sh` test suite.
 - Add 'Overclocking Bible' for RTX 40-series GPUs (`OVERCLOCKING.md`) with community-tested settings and efficiency tips.
 - Implement individual background service management with new `/api/services/restart/{service_name}` endpoint and dashboard buttons.

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=builder /app/lolMiner /app/lolMiner
 COPY --from=builder /app/t-rex /app/t-rex
 
 # Copy scripts
-COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh ./
+COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh report_generator.py ./
 COPY streamlit_app.py .
 
 RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh cuda_monitor.sh && \

--- a/Dockerfile.amd
+++ b/Dockerfile.amd
@@ -49,7 +49,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY --from=builder /app/lolMiner /app/lolMiner
 
 # Copy scripts
-COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh ./
+COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh report_generator.py ./
 COPY streamlit_app.py .
 
 RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh cuda_monitor.sh && \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This script will guide you through configuring your wallet, pool, and GPU settin
 - **Automatic Overclocking:** Apply overclocking settings to your GPUs to improve performance and efficiency.
 - **Auto-Profit Switching:** Automatically switches to the most profitable pool based on real-time stats to maximize your earnings.
 - **Telegram Notifications:** Receive instant alerts on your phone when your rig goes down or experiences zero hashrate.
+- **Hashrate Logging & Reports:** Automatically logs hashrate to CSV and generates weekly summary reports for performance tracking.
 - **Enhanced Security:** The miner runs as a non-root user (`miner`) inside the container by default. It also supports Rootless Docker environments.
 
 ## Requirements
@@ -272,6 +273,10 @@ The container has a Docker health check that verifies:
 2.  The miner is submitting hashrate.
 
 If the miner process stops, the container will be restarted immediately. If the hashrate remains at 0 for more than 5 minutes (e.g., due to a hung API or driver issue), the health check will also trigger a restart. This ensures maximum uptime and prevents "zombie" mining sessions.
+
+### Hashrate Logging and Weekly Reports
+
+The miner includes a background process that appends hashrate snapshots to `hashrate_history.csv` every minute. Additionally, it generates a weekly summary report (`weekly_report.txt`) every 24 hours, calculating the average hashrate over the last 7 days. These reports and logs can be viewed and downloaded directly from the **History** page of the web dashboard.
 
 ### Telegram Notifications
 

--- a/data/hashrate_history.csv
+++ b/data/hashrate_history.csv
@@ -1,0 +1,2 @@
+timestamp,hashrate,dual_hashrate
+2026-02-08T20:24:24.269265,251.0,0.0

--- a/data/weekly_report.txt
+++ b/data/weekly_report.txt
@@ -1,0 +1,8 @@
+Mining Weekly Report
+Generated on: 2026-02-08 20:24:24
+Period: Last 7 days
+--------------------------------------
+Total Samples: 10
+Average Hashrate: 104.50 MH/s
+Average Dual Hashrate: 54.50 MH/s
+--------------------------------------

--- a/miner_api.py
+++ b/miner_api.py
@@ -60,6 +60,7 @@ def get_services_status() -> Dict[str, str]:
     services = {
         'metrics.py': 'Stopped',
         'profit_switcher.py': 'Stopped',
+        'report_generator.py': 'Stopped',
         'cuda_monitor.sh': 'Stopped'
     }
     try:
@@ -85,6 +86,7 @@ def restart_service(service_name: str) -> bool:
     allowed_services = {
         'metrics.py': 'python3 metrics.py',
         'profit_switcher.py': 'python3 profit_switcher.py',
+        'report_generator.py': 'python3 report_generator.py',
         'cuda_monitor.sh': './cuda_monitor.sh'
     }
 

--- a/report_generator.py
+++ b/report_generator.py
@@ -1,0 +1,96 @@
+import os
+import time
+import csv
+import logging
+from datetime import datetime, timedelta
+import database
+from miner_api import get_full_miner_data
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger("report_generator")
+
+DATA_DIR = os.getenv('DATA_DIR', '/app/data')
+CSV_FILE = os.path.join(DATA_DIR, 'hashrate_history.csv')
+REPORT_FILE = os.path.join(DATA_DIR, 'weekly_report.txt')
+
+def log_to_csv():
+    try:
+        data = get_full_miner_data()
+        if not data:
+            return
+
+        timestamp = datetime.now().isoformat()
+        hashrate = data.get('total_hashrate', 0)
+        dual_hashrate = data.get('total_dual_hashrate', 0)
+
+        file_exists = os.path.isfile(CSV_FILE)
+        with open(CSV_FILE, mode='a', newline='') as f:
+            writer = csv.writer(f)
+            if not file_exists:
+                writer.writerow(['timestamp', 'hashrate', 'dual_hashrate'])
+            writer.writerow([timestamp, hashrate, dual_hashrate])
+    except Exception as e:
+        logger.error(f"Error logging to CSV: {e}")
+
+def generate_weekly_report():
+    try:
+        logger.info("Generating weekly report...")
+        history = database.get_history(days=7)
+        if not history:
+            logger.warning("No history data available for weekly report")
+            return
+
+        total_hashrate = 0
+        total_dual_hashrate = 0
+        count = len(history)
+
+        for entry in history:
+            total_hashrate += entry.get('hashrate', 0)
+            total_dual_hashrate += entry.get('dual_hashrate', 0)
+
+        avg_hashrate = total_hashrate / count if count > 0 else 0
+        avg_dual_hashrate = total_dual_hashrate / count if count > 0 else 0
+
+        report_content = f"""Mining Weekly Report
+Generated on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
+Period: Last 7 days
+--------------------------------------
+Total Samples: {count}
+Average Hashrate: {avg_hashrate:.2f} MH/s
+Average Dual Hashrate: {avg_dual_hashrate:.2f} MH/s
+--------------------------------------
+"""
+        with open(REPORT_FILE, 'w') as f:
+            f.write(report_content)
+        logger.info(f"Weekly report generated at {REPORT_FILE}")
+
+    except Exception as e:
+        logger.error(f"Error generating weekly report: {e}")
+
+def main():
+    database.init_db()
+    last_report_time = 0
+
+    # Ensure DATA_DIR exists
+    if not os.path.exists(DATA_DIR):
+        os.makedirs(DATA_DIR, exist_ok=True)
+
+    logger.info("Starting report generator background process...")
+
+    while True:
+        # Log to CSV every minute
+        log_to_csv()
+
+        # Generate report every 24 hours (for the last 7 days)
+        if time.time() - last_report_time > 86400:
+            generate_weekly_report()
+            last_report_time = time.time()
+
+        time.sleep(60)
+
+if __name__ == "__main__":
+    main()

--- a/start.sh
+++ b/start.sh
@@ -159,6 +159,9 @@ streamlit run streamlit_app.py --server.port 5000 --server.address 0.0.0.0 --ser
 # Start the profit switcher in the background
 python3 profit_switcher.py &
 
+# Start report generator in the background
+python3 report_generator.py &
+
 # Start CUDA error monitor if enabled
 if [ "$AUTO_RESTART_ON_CUDA_ERROR" = "true" ]; then
   ./cuda_monitor.sh &

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -159,6 +159,22 @@ def main():
                                 labels={'value': 'Value', 'timestamp': 'Time'},
                                 title="Average Temp and Fan Speed")
             st.plotly_chart(fig_temp, use_container_width=True)
+
+            # Weekly Report Section
+            st.divider()
+            st.subheader("Weekly Summary Report")
+            report_file = os.path.join(os.getenv('DATA_DIR', '.'), 'weekly_report.txt')
+            if os.path.exists(report_file):
+                with open(report_file, 'r') as f:
+                    st.text_area("Report Content", value=f.read(), height=200)
+
+                # Also provide CSV download
+                csv_file = os.path.join(os.getenv('DATA_DIR', '.'), 'hashrate_history.csv')
+                if os.path.exists(csv_file):
+                    with open(csv_file, 'rb') as f:
+                        st.download_button("Download Hashrate History CSV", data=f, file_name="hashrate_history.csv", mime="text/csv")
+            else:
+                st.info("Weekly report not yet generated. The report generator runs in the background.")
         else:
             st.info("No history data available")
 

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,0 +1,63 @@
+import unittest
+import os
+import csv
+import time
+from datetime import datetime, timedelta
+import report_generator
+import database
+
+class TestReportGenerator(unittest.TestCase):
+    def setUp(self):
+        self.test_data_dir = 'test_data'
+        os.makedirs(self.test_data_dir, exist_ok=True)
+        os.environ['DATA_DIR'] = self.test_data_dir
+        report_generator.DATA_DIR = self.test_data_dir
+        report_generator.CSV_FILE = os.path.join(self.test_data_dir, 'hashrate_history.csv')
+        report_generator.REPORT_FILE = os.path.join(self.test_data_dir, 'weekly_report.txt')
+        database.DB_FILE = os.path.join(self.test_data_dir, 'miner_history.db')
+        database.init_db()
+
+    def tearDown(self):
+        if os.path.exists(self.test_data_dir):
+            import shutil
+            shutil.rmtree(self.test_data_dir)
+
+    def test_log_to_csv(self):
+        # Mock GPU_MOCK to True for get_full_miner_data
+        os.environ['GPU_MOCK'] = 'true'
+        report_generator.log_to_csv()
+
+        self.assertTrue(os.path.exists(report_generator.CSV_FILE))
+        with open(report_generator.CSV_FILE, 'r') as f:
+            reader = csv.reader(f)
+            header = next(reader)
+            self.assertEqual(header, ['timestamp', 'hashrate', 'dual_hashrate'])
+            row = next(reader)
+            self.assertEqual(len(row), 3)
+            # Check if hashrate is a number
+            float(row[1])
+
+    def test_generate_weekly_report(self):
+        # Insert some dummy data into the database
+        now = datetime.now()
+        for i in range(10):
+            database.log_history(
+                hashrate=100.0 + i,
+                avg_temp=60.0,
+                avg_fan_speed=50.0,
+                accepted_shares=100,
+                rejected_shares=0,
+                dual_hashrate=50.0 + i,
+                total_power_draw=200.0
+            )
+
+        report_generator.generate_weekly_report()
+        self.assertTrue(os.path.exists(report_generator.REPORT_FILE))
+        with open(report_generator.REPORT_FILE, 'r') as f:
+            content = f.read()
+            self.assertIn("Mining Weekly Report", content)
+            self.assertIn("Average Hashrate: 104.50 MH/s", content)
+            self.assertIn("Average Dual Hashrate: 54.50 MH/s", content)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change implements a background process that logs hashrate snapshots to a CSV file every minute and generates a weekly summary report every 24 hours. The weekly report is displayed on the dashboard's History page, which also includes a button to download the full hashrate history in CSV format. This allows hobbyists to easily track their average performance over time.

Fixes #157

---
*PR created automatically by Jules for task [13364816661099083252](https://jules.google.com/task/13364816661099083252) started by @username-anthony-is-not-available*