### PR TITLE
Add Log Rotation for Miner Output and Services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && \
     python3-pip \
     nvidia-utils-525 \
     xserver-xorg \
+    logrotate \
     procps \
     gosu && \
     rm -rf /var/lib/apt/lists/*
@@ -52,7 +53,7 @@ COPY --from=builder /app/lolMiner /app/lolMiner
 COPY --from=builder /app/t-rex /app/t-rex
 
 # Copy scripts
-COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh report_generator.py ./
+COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh report_generator.py logrotate.conf ./
 COPY streamlit_app.py .
 
 RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh cuda_monitor.sh && \

--- a/Dockerfile.amd
+++ b/Dockerfile.amd
@@ -29,6 +29,7 @@ RUN apt-get update && \
     python3-pip \
     rocm-smi \
     rocm-opencl-runtime \
+    logrotate \
     clinfo \
     procps \
     gosu && \
@@ -49,7 +50,7 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY --from=builder /app/lolMiner /app/lolMiner
 
 # Copy scripts
-COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh report_generator.py ./
+COPY start.sh metrics.sh metrics.py miner_api.py healthcheck.sh restart.sh database.py gpu_profiles.json env_config.py profit_switcher.py cuda_monitor.sh report_generator.py logrotate.conf ./
 COPY streamlit_app.py .
 
 RUN chmod +x start.sh metrics.sh healthcheck.sh restart.sh cuda_monitor.sh && \

--- a/docker-compose.multi-gpu.amd.yml
+++ b/docker-compose.multi-gpu.amd.yml
@@ -31,6 +31,11 @@ services:
       - "4444:4444"
       - "4455:4455"
       - "4456:4456"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     devices:
       - "/dev/kfd:/dev/kfd"
       - "/dev/dri:/dev/dri"
@@ -52,6 +57,11 @@ services:
       - "4445:4444"
       - "4457:4455"
       - "4458:4456"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     devices:
       - "/dev/kfd:/dev/kfd"
       - "/dev/dri:/dev/dri"

--- a/docker-compose.multi-gpu.yml
+++ b/docker-compose.multi-gpu.yml
@@ -31,6 +31,11 @@ services:
       - "4444:4444"
       - "4455:4455"
       - "4456:4456"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     deploy:
       resources:
         reservations:
@@ -55,6 +60,11 @@ services:
       - "4445:4444"
       - "4457:4455"
       - "4458:4456"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       - "4455:4455"
       - "4456:4456"
       - "5000:5000"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     deploy:
       resources:
         reservations:
@@ -38,6 +43,11 @@ services:
       - "4458:4455"
       - "4459:4456"
       - "5001:5000"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     devices:
       - "/dev/kfd:/dev/kfd"
       - "/dev/dri:/dev/dri"

--- a/logrotate.conf
+++ b/logrotate.conf
@@ -1,0 +1,8 @@
+/app/data/*.log /app/data/*.csv {
+    size 10M
+    rotate 3
+    copytruncate
+    missingok
+    notifempty
+    nocompress
+}

--- a/start.sh
+++ b/start.sh
@@ -167,6 +167,14 @@ if [ "$AUTO_RESTART_ON_CUDA_ERROR" = "true" ]; then
   ./cuda_monitor.sh >> "$DATA_DIR/cuda_monitor.log" 2>&1 &
 fi
 
+# Start log rotation loop
+(
+  while true; do
+    logrotate -s "$DATA_DIR/logrotate.status" /app/logrotate.conf 2>/dev/null
+    sleep 3600
+  done
+) &
+
 # Ergo Node Sync Check
 if [ "$CHECK_NODE_SYNC" = "true" ]; then
   NODE_URL=${NODE_URL:-http://localhost:9053}

--- a/tests/test_log_rotation.sh
+++ b/tests/test_log_rotation.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+# Create a temporary directory for the test
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+echo "Using test directory: $TEST_DIR"
+
+# Create a dummy log file
+LOG_FILE="$TEST_DIR/test.log"
+echo "Dummy log content" > "$LOG_FILE"
+# Make it larger than 10M
+truncate -s 11M "$LOG_FILE"
+
+# Create a dummy csv file
+CSV_FILE="$TEST_DIR/test.csv"
+echo "col1,col2" > "$CSV_FILE"
+truncate -s 11M "$CSV_FILE"
+
+# Create a custom logrotate config for the test
+CAT_CONFIG="$TEST_DIR/logrotate.conf"
+cat <<EOF > "$CAT_CONFIG"
+$TEST_DIR/*.log $TEST_DIR/*.csv {
+    size 10M
+    rotate 3
+    copytruncate
+    missingok
+    notifempty
+    nocompress
+}
+EOF
+
+# Run logrotate
+# Note: logrotate might complain about permissions if the config is not owned by root,
+# but usually it's fine when running as the same user.
+/usr/sbin/logrotate -s "$TEST_DIR/status" "$CAT_CONFIG" --force
+
+# Verify rotation
+if [ -f "$LOG_FILE.1" ]; then
+    echo "Log file was successfully rotated to $LOG_FILE.1"
+else
+    echo "FAILED: Log file was not rotated"
+    ls -l "$TEST_DIR"
+    exit 1
+fi
+
+if [ -f "$CSV_FILE.1" ]; then
+    echo "CSV file was successfully rotated to $CSV_FILE.1"
+else
+    echo "FAILED: CSV file was not rotated"
+    ls -l "$TEST_DIR"
+    exit 1
+fi
+
+# Check original files are truncated
+LOG_SIZE=$(stat -c%s "$LOG_FILE")
+if [ "$LOG_SIZE" -eq 0 ]; then
+    echo "Original log file was successfully truncated"
+else
+    echo "FAILED: Original log file was not truncated (size: $LOG_SIZE)"
+    exit 1
+fi
+
+echo "Log rotation test passed!"


### PR DESCRIPTION
This PR implements log rotation to prevent the miner's disk from filling up over time. It addresses both internal application logs (stored in the data directory) and Docker container logs.

Key changes:
1.  **Internal Log Rotation:** Added `logrotate` to the runtime images and configured it to rotate `*.log` and `*.csv` files in `/app/data` when they exceed 10MB, keeping up to 3 old versions. Used `copytruncate` to ensure compatibility with active log redirections.
2.  **Docker Log Limits:** Updated all `docker-compose.yml` variants to include logging limits (`max-size: 10m`, `max-file: 3`) for the container stdout/stderr logs.
3.  **Automation:** Added a background loop in `start.sh` that runs `logrotate` every hour.
4.  **Verification:** Included a new test script `tests/test_log_rotation.sh` that validates the rotation and truncation logic. All existing tests passed.

Fixes #132

---
*PR created automatically by Jules for task [18350030824210402456](https://jules.google.com/task/18350030824210402456) started by @username-anthony-is-not-available*